### PR TITLE
Add files via upload

### DIFF
--- a/606e6f41-a8a0-4bd5-827e-0abffdf62354.svg
+++ b/606e6f41-a8a0-4bd5-827e-0abffdf62354.svg
@@ -1,0 +1,1265 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280.000000 980.000000" width="1280.000000" height="980.000000">
+  <rect x="0" y="0" width="1280.000000" height="980.000000" fill="#050509"/>
+  <text x="24" y="34" fill="#eee" font-family="monospace" font-size="20">Pascal ⇄ conflation lenses — each entry focuses its own prime-power towers</text>
+  <text x="24" y="58" fill="#888" font-family="monospace" font-size="12">each entry C(r,c) → one lens conflating its towers p^vₚ(C(r,c)) as base-p space-filling curves (2 Hilbert · rest Peano)</text>
+  <text x="24" y="76" fill="#777" font-family="monospace" font-size="11">within every lens the towers are screen-blended · spun at their own rate (interference) · pulsed to cohere ⇄ decohere; mirror entries share a signature (entryExps_symm)</text>
+  <text x="24" y="94" fill="#666" font-family="monospace" font-size="10">exponent vₚ = number of base-p carries in c+(r−c) (Kummer); every tower p^vₚ divides C(r,c) (entry_ogg_dvd)</text>
+  <text x="24" y="112" fill="#555" font-family="monospace" font-size="10">colours — 2 cyan · 3 magenta · 5 amber · 7 green · 11 orange · 13 violet · 17 teal · 19 red · 23 blue · 29 lime · 31 pink · 41 mint · 47 tan · 59 indigo · 71 white</text>
+  <circle cx="640.000000" cy="150.000000" r="27.000000" fill="#05050c" stroke="hsl(0.000000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.000000s" repeatCount="indefinite"/>
+  </g>
+  <text x="640.000000" y="122.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="596.000000" cy="212.000000" r="27.000000" fill="#05050c" stroke="hsl(137.508000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.190000s" repeatCount="indefinite"/>
+  </g>
+  <text x="596.000000" y="184.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="684.000000" cy="212.000000" r="27.000000" fill="#05050c" stroke="hsl(275.016000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.380000s" repeatCount="indefinite"/>
+  </g>
+  <text x="684.000000" y="184.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="552.000000" cy="274.000000" r="27.000000" fill="#05050c" stroke="hsl(275.016000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.570000s" repeatCount="indefinite"/>
+  </g>
+  <text x="552.000000" y="246.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="640.000000" cy="274.000000" r="27.000000" fill="#05050c" stroke="hsl(412.524000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.760000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 274.000000" to="635.016000 640.000000 274.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,249.000000 615.000000,299.000000 665.000000,299.000000 665.000000,249.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="246.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">2</text>
+  <circle cx="728.000000" cy="274.000000" r="27.000000" fill="#05050c" stroke="hsl(550.032000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-0.950000s" repeatCount="indefinite"/>
+  </g>
+  <text x="728.000000" y="246.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="508.000000" cy="336.000000" r="27.000000" fill="#05050c" stroke="hsl(412.524000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-1.140000s" repeatCount="indefinite"/>
+  </g>
+  <text x="508.000000" y="308.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="596.000000" cy="336.000000" r="27.000000" fill="#05050c" stroke="hsl(550.032000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-1.330000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 596.000000 336.000000" to="465.048000 596.000000 336.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,311.000000 571.000000,336.000000 571.000000,361.000000 596.000000,361.000000 596.000000,336.000000 596.000000,311.000000 621.000000,311.000000 621.000000,336.000000 621.000000,361.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="308.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">3</text>
+  <circle cx="684.000000" cy="336.000000" r="27.000000" fill="#05050c" stroke="hsl(687.540000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-1.520000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 684.000000 336.000000" to="465.048000 684.000000 336.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,311.000000 659.000000,336.000000 659.000000,361.000000 684.000000,361.000000 684.000000,336.000000 684.000000,311.000000 709.000000,311.000000 709.000000,336.000000 709.000000,361.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="308.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">3</text>
+  <circle cx="772.000000" cy="336.000000" r="27.000000" fill="#05050c" stroke="hsl(825.048000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-1.710000s" repeatCount="indefinite"/>
+  </g>
+  <text x="772.000000" y="308.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="464.000000" cy="398.000000" r="27.000000" fill="#05050c" stroke="hsl(550.032000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-1.900000s" repeatCount="indefinite"/>
+  </g>
+  <text x="464.000000" y="370.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="552.000000" cy="398.000000" r="27.000000" fill="#05050c" stroke="hsl(687.540000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-2.090000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 552.000000 398.000000" to="635.016000 552.000000 398.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,373.000000 527.000000,423.000000 577.000000,423.000000 577.000000,373.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="552.000000" y="370.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">4</text>
+  <circle cx="640.000000" cy="398.000000" r="27.000000" fill="#05050c" stroke="hsl(825.048000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-2.280000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 398.000000" to="635.016000 640.000000 398.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,373.000000 615.000000,423.000000 665.000000,423.000000 665.000000,373.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 640.000000 398.000000" to="465.048000 640.000000 398.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,373.000000 615.000000,398.000000 615.000000,423.000000 640.000000,423.000000 640.000000,398.000000 640.000000,373.000000 665.000000,373.000000 665.000000,398.000000 665.000000,423.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="370.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">6</text>
+  <circle cx="728.000000" cy="398.000000" r="27.000000" fill="#05050c" stroke="hsl(962.556000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-2.470000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 728.000000 398.000000" to="635.016000 728.000000 398.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,373.000000 703.000000,423.000000 753.000000,423.000000 753.000000,373.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="728.000000" y="370.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">4</text>
+  <circle cx="816.000000" cy="398.000000" r="27.000000" fill="#05050c" stroke="hsl(1100.064000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-2.660000s" repeatCount="indefinite"/>
+  </g>
+  <text x="816.000000" y="370.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="420.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(687.540000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-2.850000s" repeatCount="indefinite"/>
+  </g>
+  <text x="420.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="508.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(825.048000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.040000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 508.000000 460.000000" to="2422.620000 508.000000 460.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,435.000000 483.000000,447.500000 483.000000,460.000000 483.000000,472.500000 483.000000,485.000000 495.500000,485.000000 495.500000,472.500000 495.500000,460.000000 495.500000,447.500000 495.500000,435.000000 508.000000,435.000000 508.000000,447.500000 508.000000,460.000000 508.000000,472.500000 508.000000,485.000000 520.500000,485.000000 520.500000,472.500000 520.500000,460.000000 520.500000,447.500000 520.500000,435.000000 533.000000,435.000000 533.000000,447.500000 533.000000,460.000000 533.000000,472.500000 533.000000,485.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="508.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">5</text>
+  <circle cx="596.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(962.556000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.230000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 596.000000 460.000000" to="635.016000 596.000000 460.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,435.000000 571.000000,485.000000 621.000000,485.000000 621.000000,435.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 596.000000 460.000000" to="2422.620000 596.000000 460.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,435.000000 571.000000,447.500000 571.000000,460.000000 571.000000,472.500000 571.000000,485.000000 583.500000,485.000000 583.500000,472.500000 583.500000,460.000000 583.500000,447.500000 583.500000,435.000000 596.000000,435.000000 596.000000,447.500000 596.000000,460.000000 596.000000,472.500000 596.000000,485.000000 608.500000,485.000000 608.500000,472.500000 608.500000,460.000000 608.500000,447.500000 608.500000,435.000000 621.000000,435.000000 621.000000,447.500000 621.000000,460.000000 621.000000,472.500000 621.000000,485.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">10</text>
+  <circle cx="684.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(1100.064000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.420000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 684.000000 460.000000" to="635.016000 684.000000 460.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,435.000000 659.000000,485.000000 709.000000,485.000000 709.000000,435.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 684.000000 460.000000" to="2422.620000 684.000000 460.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,435.000000 659.000000,447.500000 659.000000,460.000000 659.000000,472.500000 659.000000,485.000000 671.500000,485.000000 671.500000,472.500000 671.500000,460.000000 671.500000,447.500000 671.500000,435.000000 684.000000,435.000000 684.000000,447.500000 684.000000,460.000000 684.000000,472.500000 684.000000,485.000000 696.500000,485.000000 696.500000,472.500000 696.500000,460.000000 696.500000,447.500000 696.500000,435.000000 709.000000,435.000000 709.000000,447.500000 709.000000,460.000000 709.000000,472.500000 709.000000,485.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">10</text>
+  <circle cx="772.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(1237.572000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.610000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 772.000000 460.000000" to="2422.620000 772.000000 460.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,435.000000 747.000000,447.500000 747.000000,460.000000 747.000000,472.500000 747.000000,485.000000 759.500000,485.000000 759.500000,472.500000 759.500000,460.000000 759.500000,447.500000 759.500000,435.000000 772.000000,435.000000 772.000000,447.500000 772.000000,460.000000 772.000000,472.500000 772.000000,485.000000 784.500000,485.000000 784.500000,472.500000 784.500000,460.000000 784.500000,447.500000 784.500000,435.000000 797.000000,435.000000 797.000000,447.500000 797.000000,460.000000 797.000000,472.500000 797.000000,485.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="772.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">5</text>
+  <circle cx="860.000000" cy="460.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.800000s" repeatCount="indefinite"/>
+  </g>
+  <text x="860.000000" y="432.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="376.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(825.048000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-3.990000s" repeatCount="indefinite"/>
+  </g>
+  <text x="376.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="464.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(962.556000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-4.180000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 464.000000 522.000000" to="635.016000 464.000000 522.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,497.000000 439.000000,547.000000 489.000000,547.000000 489.000000,497.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 464.000000 522.000000" to="465.048000 464.000000 522.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,497.000000 439.000000,522.000000 439.000000,547.000000 464.000000,547.000000 464.000000,522.000000 464.000000,497.000000 489.000000,497.000000 489.000000,522.000000 489.000000,547.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="464.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">6</text>
+  <circle cx="552.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(1100.064000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-4.370000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 552.000000 522.000000" to="465.048000 552.000000 522.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,497.000000 527.000000,522.000000 527.000000,547.000000 552.000000,547.000000 552.000000,522.000000 552.000000,497.000000 577.000000,497.000000 577.000000,522.000000 577.000000,547.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 552.000000 522.000000" to="2422.620000 552.000000 522.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,497.000000 527.000000,509.500000 527.000000,522.000000 527.000000,534.500000 527.000000,547.000000 539.500000,547.000000 539.500000,534.500000 539.500000,522.000000 539.500000,509.500000 539.500000,497.000000 552.000000,497.000000 552.000000,509.500000 552.000000,522.000000 552.000000,534.500000 552.000000,547.000000 564.500000,547.000000 564.500000,534.500000 564.500000,522.000000 564.500000,509.500000 564.500000,497.000000 577.000000,497.000000 577.000000,509.500000 577.000000,522.000000 577.000000,534.500000 577.000000,547.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="552.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">15</text>
+  <circle cx="640.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(1237.572000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-4.560000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 522.000000" to="635.016000 640.000000 522.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,497.000000 615.000000,547.000000 665.000000,547.000000 665.000000,497.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 640.000000 522.000000" to="2422.620000 640.000000 522.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,497.000000 615.000000,509.500000 615.000000,522.000000 615.000000,534.500000 615.000000,547.000000 627.500000,547.000000 627.500000,534.500000 627.500000,522.000000 627.500000,509.500000 627.500000,497.000000 640.000000,497.000000 640.000000,509.500000 640.000000,522.000000 640.000000,534.500000 640.000000,547.000000 652.500000,547.000000 652.500000,534.500000 652.500000,522.000000 652.500000,509.500000 652.500000,497.000000 665.000000,497.000000 665.000000,509.500000 665.000000,522.000000 665.000000,534.500000 665.000000,547.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">20</text>
+  <circle cx="728.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-4.750000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 728.000000 522.000000" to="465.048000 728.000000 522.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,497.000000 703.000000,522.000000 703.000000,547.000000 728.000000,547.000000 728.000000,522.000000 728.000000,497.000000 753.000000,497.000000 753.000000,522.000000 753.000000,547.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 728.000000 522.000000" to="2422.620000 728.000000 522.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,497.000000 703.000000,509.500000 703.000000,522.000000 703.000000,534.500000 703.000000,547.000000 715.500000,547.000000 715.500000,534.500000 715.500000,522.000000 715.500000,509.500000 715.500000,497.000000 728.000000,497.000000 728.000000,509.500000 728.000000,522.000000 728.000000,534.500000 728.000000,547.000000 740.500000,547.000000 740.500000,534.500000 740.500000,522.000000 740.500000,509.500000 740.500000,497.000000 753.000000,497.000000 753.000000,509.500000 753.000000,522.000000 753.000000,534.500000 753.000000,547.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="728.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">15</text>
+  <circle cx="816.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-4.940000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 816.000000 522.000000" to="635.016000 816.000000 522.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,497.000000 791.000000,547.000000 841.000000,547.000000 841.000000,497.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 816.000000 522.000000" to="465.048000 816.000000 522.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,497.000000 791.000000,522.000000 791.000000,547.000000 816.000000,547.000000 816.000000,522.000000 816.000000,497.000000 841.000000,497.000000 841.000000,522.000000 841.000000,547.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="816.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">6</text>
+  <circle cx="904.000000" cy="522.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-5.130000s" repeatCount="indefinite"/>
+  </g>
+  <text x="904.000000" y="494.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="332.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(962.556000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-5.320000s" repeatCount="indefinite"/>
+  </g>
+  <text x="332.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="420.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1100.064000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-5.510000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 420.000000 584.000000" to="3490.224000 420.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,559.000000 395.000000,567.333333 395.000000,575.666667 395.000000,584.000000 395.000000,592.333333 395.000000,600.666667 395.000000,609.000000 403.333333,609.000000 403.333333,600.666667 403.333333,584.000000 403.333333,575.666667 403.333333,567.333333 403.333333,559.000000 411.666667,559.000000 411.666667,567.333333 411.666667,575.666667 411.666667,584.000000 411.666667,592.333333 411.666667,609.000000 420.000000,609.000000 420.000000,600.666667 420.000000,592.333333 420.000000,584.000000 420.000000,575.666667 420.000000,567.333333 420.000000,559.000000 428.333333,567.333333 428.333333,575.666667 428.333333,584.000000 428.333333,592.333333 428.333333,600.666667 428.333333,609.000000 436.666667,609.000000 436.666667,600.666667 436.666667,592.333333 436.666667,575.666667 436.666667,567.333333 436.666667,559.000000 445.000000,559.000000 445.000000,567.333333 445.000000,575.666667 445.000000,584.000000 445.000000,592.333333 445.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="420.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">7</text>
+  <circle cx="508.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1237.572000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-5.700000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 508.000000 584.000000" to="465.048000 508.000000 584.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,559.000000 483.000000,584.000000 483.000000,609.000000 508.000000,609.000000 508.000000,584.000000 508.000000,559.000000 533.000000,559.000000 533.000000,584.000000 533.000000,609.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 508.000000 584.000000" to="3490.224000 508.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,559.000000 483.000000,567.333333 483.000000,575.666667 483.000000,584.000000 483.000000,592.333333 483.000000,600.666667 483.000000,609.000000 491.333333,609.000000 491.333333,600.666667 491.333333,584.000000 491.333333,575.666667 491.333333,567.333333 491.333333,559.000000 499.666667,559.000000 499.666667,567.333333 499.666667,575.666667 499.666667,584.000000 499.666667,592.333333 499.666667,609.000000 508.000000,609.000000 508.000000,600.666667 508.000000,592.333333 508.000000,584.000000 508.000000,575.666667 508.000000,567.333333 508.000000,559.000000 516.333333,567.333333 516.333333,575.666667 516.333333,584.000000 516.333333,592.333333 516.333333,600.666667 516.333333,609.000000 524.666667,609.000000 524.666667,600.666667 524.666667,592.333333 524.666667,575.666667 524.666667,567.333333 524.666667,559.000000 533.000000,559.000000 533.000000,567.333333 533.000000,575.666667 533.000000,584.000000 533.000000,592.333333 533.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="508.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">21</text>
+  <circle cx="596.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-5.890000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 596.000000 584.000000" to="2422.620000 596.000000 584.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,559.000000 571.000000,571.500000 571.000000,584.000000 571.000000,596.500000 571.000000,609.000000 583.500000,609.000000 583.500000,596.500000 583.500000,584.000000 583.500000,571.500000 583.500000,559.000000 596.000000,559.000000 596.000000,571.500000 596.000000,584.000000 596.000000,596.500000 596.000000,609.000000 608.500000,609.000000 608.500000,596.500000 608.500000,584.000000 608.500000,571.500000 608.500000,559.000000 621.000000,559.000000 621.000000,571.500000 621.000000,584.000000 621.000000,596.500000 621.000000,609.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 596.000000 584.000000" to="3490.224000 596.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,559.000000 571.000000,567.333333 571.000000,575.666667 571.000000,584.000000 571.000000,592.333333 571.000000,600.666667 571.000000,609.000000 579.333333,609.000000 579.333333,600.666667 579.333333,584.000000 579.333333,575.666667 579.333333,567.333333 579.333333,559.000000 587.666667,559.000000 587.666667,567.333333 587.666667,575.666667 587.666667,584.000000 587.666667,592.333333 587.666667,609.000000 596.000000,609.000000 596.000000,600.666667 596.000000,592.333333 596.000000,584.000000 596.000000,575.666667 596.000000,567.333333 596.000000,559.000000 604.333333,567.333333 604.333333,575.666667 604.333333,584.000000 604.333333,592.333333 604.333333,600.666667 604.333333,609.000000 612.666667,609.000000 612.666667,600.666667 612.666667,592.333333 612.666667,575.666667 612.666667,567.333333 612.666667,559.000000 621.000000,559.000000 621.000000,567.333333 621.000000,575.666667 621.000000,584.000000 621.000000,592.333333 621.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">35</text>
+  <circle cx="684.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-6.080000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 684.000000 584.000000" to="2422.620000 684.000000 584.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,559.000000 659.000000,571.500000 659.000000,584.000000 659.000000,596.500000 659.000000,609.000000 671.500000,609.000000 671.500000,596.500000 671.500000,584.000000 671.500000,571.500000 671.500000,559.000000 684.000000,559.000000 684.000000,571.500000 684.000000,584.000000 684.000000,596.500000 684.000000,609.000000 696.500000,609.000000 696.500000,596.500000 696.500000,584.000000 696.500000,571.500000 696.500000,559.000000 709.000000,559.000000 709.000000,571.500000 709.000000,584.000000 709.000000,596.500000 709.000000,609.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 684.000000 584.000000" to="3490.224000 684.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,559.000000 659.000000,567.333333 659.000000,575.666667 659.000000,584.000000 659.000000,592.333333 659.000000,600.666667 659.000000,609.000000 667.333333,609.000000 667.333333,600.666667 667.333333,584.000000 667.333333,575.666667 667.333333,567.333333 667.333333,559.000000 675.666667,559.000000 675.666667,567.333333 675.666667,575.666667 675.666667,584.000000 675.666667,592.333333 675.666667,609.000000 684.000000,609.000000 684.000000,600.666667 684.000000,592.333333 684.000000,584.000000 684.000000,575.666667 684.000000,567.333333 684.000000,559.000000 692.333333,567.333333 692.333333,575.666667 692.333333,584.000000 692.333333,592.333333 692.333333,600.666667 692.333333,609.000000 700.666667,609.000000 700.666667,600.666667 700.666667,592.333333 700.666667,575.666667 700.666667,567.333333 700.666667,559.000000 709.000000,559.000000 709.000000,567.333333 709.000000,575.666667 709.000000,584.000000 709.000000,592.333333 709.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">35</text>
+  <circle cx="772.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-6.270000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 772.000000 584.000000" to="465.048000 772.000000 584.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,559.000000 747.000000,584.000000 747.000000,609.000000 772.000000,609.000000 772.000000,584.000000 772.000000,559.000000 797.000000,559.000000 797.000000,584.000000 797.000000,609.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 772.000000 584.000000" to="3490.224000 772.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,559.000000 747.000000,567.333333 747.000000,575.666667 747.000000,584.000000 747.000000,592.333333 747.000000,600.666667 747.000000,609.000000 755.333333,609.000000 755.333333,600.666667 755.333333,584.000000 755.333333,575.666667 755.333333,567.333333 755.333333,559.000000 763.666667,559.000000 763.666667,567.333333 763.666667,575.666667 763.666667,584.000000 763.666667,592.333333 763.666667,609.000000 772.000000,609.000000 772.000000,600.666667 772.000000,592.333333 772.000000,584.000000 772.000000,575.666667 772.000000,567.333333 772.000000,559.000000 780.333333,567.333333 780.333333,575.666667 780.333333,584.000000 780.333333,592.333333 780.333333,600.666667 780.333333,609.000000 788.666667,609.000000 788.666667,600.666667 788.666667,592.333333 788.666667,575.666667 788.666667,567.333333 788.666667,559.000000 797.000000,559.000000 797.000000,567.333333 797.000000,575.666667 797.000000,584.000000 797.000000,592.333333 797.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="772.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">21</text>
+  <circle cx="860.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-6.460000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 860.000000 584.000000" to="3490.224000 860.000000 584.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,559.000000 835.000000,567.333333 835.000000,575.666667 835.000000,584.000000 835.000000,592.333333 835.000000,600.666667 835.000000,609.000000 843.333333,609.000000 843.333333,600.666667 843.333333,584.000000 843.333333,575.666667 843.333333,567.333333 843.333333,559.000000 851.666667,559.000000 851.666667,567.333333 851.666667,575.666667 851.666667,584.000000 851.666667,592.333333 851.666667,609.000000 860.000000,609.000000 860.000000,600.666667 860.000000,592.333333 860.000000,584.000000 860.000000,575.666667 860.000000,567.333333 860.000000,559.000000 868.333333,567.333333 868.333333,575.666667 868.333333,584.000000 868.333333,592.333333 868.333333,600.666667 868.333333,609.000000 876.666667,609.000000 876.666667,600.666667 876.666667,592.333333 876.666667,575.666667 876.666667,567.333333 876.666667,559.000000 885.000000,559.000000 885.000000,567.333333 885.000000,575.666667 885.000000,584.000000 885.000000,592.333333 885.000000,609.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="860.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">7</text>
+  <circle cx="948.000000" cy="584.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-6.650000s" repeatCount="indefinite"/>
+  </g>
+  <text x="948.000000" y="556.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="288.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1100.064000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-6.840000s" repeatCount="indefinite"/>
+  </g>
+  <text x="288.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="376.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1237.572000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.030000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 376.000000 646.000000" to="635.016000 376.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,621.000000 367.666667,621.000000 367.666667,637.666667 351.000000,637.666667 351.000000,654.333333 351.000000,671.000000 367.666667,671.000000 367.666667,654.333333 384.333333,654.333333 384.333333,671.000000 401.000000,671.000000 401.000000,654.333333 401.000000,637.666667 384.333333,637.666667 384.333333,621.000000 401.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="376.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">8</text>
+  <circle cx="464.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.220000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 464.000000 646.000000" to="635.016000 464.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,621.000000 439.000000,671.000000 489.000000,671.000000 489.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 464.000000 646.000000" to="3490.224000 464.000000 646.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,621.000000 439.000000,629.333333 439.000000,637.666667 439.000000,646.000000 439.000000,654.333333 439.000000,662.666667 439.000000,671.000000 447.333333,671.000000 447.333333,662.666667 447.333333,646.000000 447.333333,637.666667 447.333333,629.333333 447.333333,621.000000 455.666667,621.000000 455.666667,629.333333 455.666667,637.666667 455.666667,646.000000 455.666667,654.333333 455.666667,671.000000 464.000000,671.000000 464.000000,662.666667 464.000000,654.333333 464.000000,646.000000 464.000000,637.666667 464.000000,629.333333 464.000000,621.000000 472.333333,629.333333 472.333333,637.666667 472.333333,646.000000 472.333333,654.333333 472.333333,662.666667 472.333333,671.000000 480.666667,671.000000 480.666667,662.666667 480.666667,654.333333 480.666667,637.666667 480.666667,629.333333 480.666667,621.000000 489.000000,621.000000 489.000000,629.333333 489.000000,637.666667 489.000000,646.000000 489.000000,654.333333 489.000000,671.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="464.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">28</text>
+  <circle cx="552.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.410000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 552.000000 646.000000" to="635.016000 552.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,621.000000 543.666667,621.000000 543.666667,637.666667 527.000000,637.666667 527.000000,654.333333 527.000000,671.000000 543.666667,671.000000 543.666667,654.333333 560.333333,654.333333 560.333333,671.000000 577.000000,671.000000 577.000000,654.333333 577.000000,637.666667 560.333333,637.666667 560.333333,621.000000 577.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 552.000000 646.000000" to="3490.224000 552.000000 646.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,621.000000 527.000000,629.333333 527.000000,637.666667 527.000000,646.000000 527.000000,654.333333 527.000000,662.666667 527.000000,671.000000 535.333333,671.000000 535.333333,662.666667 535.333333,646.000000 535.333333,637.666667 535.333333,629.333333 535.333333,621.000000 543.666667,621.000000 543.666667,629.333333 543.666667,637.666667 543.666667,646.000000 543.666667,654.333333 543.666667,671.000000 552.000000,671.000000 552.000000,662.666667 552.000000,654.333333 552.000000,646.000000 552.000000,637.666667 552.000000,629.333333 552.000000,621.000000 560.333333,629.333333 560.333333,637.666667 560.333333,646.000000 560.333333,654.333333 560.333333,662.666667 560.333333,671.000000 568.666667,671.000000 568.666667,662.666667 568.666667,654.333333 568.666667,637.666667 568.666667,629.333333 568.666667,621.000000 577.000000,621.000000 577.000000,629.333333 577.000000,637.666667 577.000000,646.000000 577.000000,654.333333 577.000000,671.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="552.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">56</text>
+  <circle cx="640.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.600000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 646.000000" to="635.016000 640.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,621.000000 615.000000,671.000000 665.000000,671.000000 665.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 640.000000 646.000000" to="2422.620000 640.000000 646.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,621.000000 615.000000,633.500000 615.000000,646.000000 615.000000,658.500000 615.000000,671.000000 627.500000,671.000000 627.500000,658.500000 627.500000,646.000000 627.500000,633.500000 627.500000,621.000000 640.000000,621.000000 640.000000,633.500000 640.000000,646.000000 640.000000,658.500000 640.000000,671.000000 652.500000,671.000000 652.500000,658.500000 652.500000,646.000000 652.500000,633.500000 652.500000,621.000000 665.000000,621.000000 665.000000,633.500000 665.000000,646.000000 665.000000,658.500000 665.000000,671.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 640.000000 646.000000" to="3490.224000 640.000000 646.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,621.000000 615.000000,629.333333 615.000000,637.666667 615.000000,646.000000 615.000000,654.333333 615.000000,662.666667 615.000000,671.000000 623.333333,671.000000 623.333333,662.666667 623.333333,646.000000 623.333333,637.666667 623.333333,629.333333 623.333333,621.000000 631.666667,621.000000 631.666667,629.333333 631.666667,637.666667 631.666667,646.000000 631.666667,654.333333 631.666667,671.000000 640.000000,671.000000 640.000000,662.666667 640.000000,654.333333 640.000000,646.000000 640.000000,637.666667 640.000000,629.333333 640.000000,621.000000 648.333333,629.333333 648.333333,637.666667 648.333333,646.000000 648.333333,654.333333 648.333333,662.666667 648.333333,671.000000 656.666667,671.000000 656.666667,662.666667 656.666667,654.333333 656.666667,637.666667 656.666667,629.333333 656.666667,621.000000 665.000000,621.000000 665.000000,629.333333 665.000000,637.666667 665.000000,646.000000 665.000000,654.333333 665.000000,671.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">70</text>
+  <circle cx="728.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.790000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 728.000000 646.000000" to="635.016000 728.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,621.000000 719.666667,621.000000 719.666667,637.666667 703.000000,637.666667 703.000000,654.333333 703.000000,671.000000 719.666667,671.000000 719.666667,654.333333 736.333333,654.333333 736.333333,671.000000 753.000000,671.000000 753.000000,654.333333 753.000000,637.666667 736.333333,637.666667 736.333333,621.000000 753.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 728.000000 646.000000" to="3490.224000 728.000000 646.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,621.000000 703.000000,629.333333 703.000000,637.666667 703.000000,646.000000 703.000000,654.333333 703.000000,662.666667 703.000000,671.000000 711.333333,671.000000 711.333333,662.666667 711.333333,646.000000 711.333333,637.666667 711.333333,629.333333 711.333333,621.000000 719.666667,621.000000 719.666667,629.333333 719.666667,637.666667 719.666667,646.000000 719.666667,654.333333 719.666667,671.000000 728.000000,671.000000 728.000000,662.666667 728.000000,654.333333 728.000000,646.000000 728.000000,637.666667 728.000000,629.333333 728.000000,621.000000 736.333333,629.333333 736.333333,637.666667 736.333333,646.000000 736.333333,654.333333 736.333333,662.666667 736.333333,671.000000 744.666667,671.000000 744.666667,662.666667 744.666667,654.333333 744.666667,637.666667 744.666667,629.333333 744.666667,621.000000 753.000000,621.000000 753.000000,629.333333 753.000000,637.666667 753.000000,646.000000 753.000000,654.333333 753.000000,671.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="728.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">56</text>
+  <circle cx="816.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-7.980000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 816.000000 646.000000" to="635.016000 816.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,621.000000 791.000000,671.000000 841.000000,671.000000 841.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 816.000000 646.000000" to="3490.224000 816.000000 646.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,621.000000 791.000000,629.333333 791.000000,637.666667 791.000000,646.000000 791.000000,654.333333 791.000000,662.666667 791.000000,671.000000 799.333333,671.000000 799.333333,662.666667 799.333333,646.000000 799.333333,637.666667 799.333333,629.333333 799.333333,621.000000 807.666667,621.000000 807.666667,629.333333 807.666667,637.666667 807.666667,646.000000 807.666667,654.333333 807.666667,671.000000 816.000000,671.000000 816.000000,662.666667 816.000000,654.333333 816.000000,646.000000 816.000000,637.666667 816.000000,629.333333 816.000000,621.000000 824.333333,629.333333 824.333333,637.666667 824.333333,646.000000 824.333333,654.333333 824.333333,662.666667 824.333333,671.000000 832.666667,671.000000 832.666667,662.666667 832.666667,654.333333 832.666667,637.666667 832.666667,629.333333 832.666667,621.000000 841.000000,621.000000 841.000000,629.333333 841.000000,637.666667 841.000000,646.000000 841.000000,654.333333 841.000000,671.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="816.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">28</text>
+  <circle cx="904.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-8.170000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 904.000000 646.000000" to="635.016000 904.000000 646.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,621.000000 895.666667,621.000000 895.666667,637.666667 879.000000,637.666667 879.000000,654.333333 879.000000,671.000000 895.666667,671.000000 895.666667,654.333333 912.333333,654.333333 912.333333,671.000000 929.000000,671.000000 929.000000,654.333333 929.000000,637.666667 912.333333,637.666667 912.333333,621.000000 929.000000,621.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="904.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">8</text>
+  <circle cx="992.000000" cy="646.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-8.360000s" repeatCount="indefinite"/>
+  </g>
+  <text x="992.000000" y="618.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="244.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1237.572000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-8.550000s" repeatCount="indefinite"/>
+  </g>
+  <text x="244.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="332.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-8.740000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 332.000000 708.000000" to="465.048000 332.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,683.000000 307.000000,708.000000 307.000000,733.000000 332.000000,733.000000 332.000000,708.000000 332.000000,683.000000 357.000000,683.000000 357.000000,708.000000 357.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="332.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">9</text>
+  <circle cx="420.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-8.930000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 420.000000 708.000000" to="635.016000 420.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,683.000000 395.000000,733.000000 445.000000,733.000000 445.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 420.000000 708.000000" to="465.048000 420.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,683.000000 395.000000,708.000000 395.000000,733.000000 420.000000,733.000000 420.000000,708.000000 420.000000,683.000000 445.000000,683.000000 445.000000,708.000000 445.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="420.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">36</text>
+  <circle cx="508.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-9.120000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 508.000000 708.000000" to="635.016000 508.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,683.000000 483.000000,733.000000 533.000000,733.000000 533.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 508.000000 708.000000" to="465.048000 508.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,683.000000 483.000000,708.000000 483.000000,733.000000 508.000000,733.000000 508.000000,708.000000 508.000000,683.000000 533.000000,683.000000 533.000000,708.000000 533.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 508.000000 708.000000" to="3490.224000 508.000000 708.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,683.000000 483.000000,691.333333 483.000000,699.666667 483.000000,708.000000 483.000000,716.333333 483.000000,724.666667 483.000000,733.000000 491.333333,733.000000 491.333333,724.666667 491.333333,708.000000 491.333333,699.666667 491.333333,691.333333 491.333333,683.000000 499.666667,683.000000 499.666667,691.333333 499.666667,699.666667 499.666667,708.000000 499.666667,716.333333 499.666667,733.000000 508.000000,733.000000 508.000000,724.666667 508.000000,716.333333 508.000000,708.000000 508.000000,699.666667 508.000000,691.333333 508.000000,683.000000 516.333333,691.333333 516.333333,699.666667 516.333333,708.000000 516.333333,716.333333 516.333333,724.666667 516.333333,733.000000 524.666667,733.000000 524.666667,724.666667 524.666667,716.333333 524.666667,699.666667 524.666667,691.333333 524.666667,683.000000 533.000000,683.000000 533.000000,691.333333 533.000000,699.666667 533.000000,708.000000 533.000000,716.333333 533.000000,733.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="508.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">84</text>
+  <circle cx="596.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-9.310000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 596.000000 708.000000" to="635.016000 596.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,683.000000 571.000000,733.000000 621.000000,733.000000 621.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 596.000000 708.000000" to="465.048000 596.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,683.000000 571.000000,708.000000 571.000000,733.000000 596.000000,733.000000 596.000000,708.000000 596.000000,683.000000 621.000000,683.000000 621.000000,708.000000 621.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 596.000000 708.000000" to="3490.224000 596.000000 708.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,683.000000 571.000000,691.333333 571.000000,699.666667 571.000000,708.000000 571.000000,716.333333 571.000000,724.666667 571.000000,733.000000 579.333333,733.000000 579.333333,724.666667 579.333333,708.000000 579.333333,699.666667 579.333333,691.333333 579.333333,683.000000 587.666667,683.000000 587.666667,691.333333 587.666667,699.666667 587.666667,708.000000 587.666667,716.333333 587.666667,733.000000 596.000000,733.000000 596.000000,724.666667 596.000000,716.333333 596.000000,708.000000 596.000000,699.666667 596.000000,691.333333 596.000000,683.000000 604.333333,691.333333 604.333333,699.666667 604.333333,708.000000 604.333333,716.333333 604.333333,724.666667 604.333333,733.000000 612.666667,733.000000 612.666667,724.666667 612.666667,716.333333 612.666667,699.666667 612.666667,691.333333 612.666667,683.000000 621.000000,683.000000 621.000000,691.333333 621.000000,699.666667 621.000000,708.000000 621.000000,716.333333 621.000000,733.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">126</text>
+  <circle cx="684.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-9.500000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 684.000000 708.000000" to="635.016000 684.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,683.000000 659.000000,733.000000 709.000000,733.000000 709.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 684.000000 708.000000" to="465.048000 684.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,683.000000 659.000000,708.000000 659.000000,733.000000 684.000000,733.000000 684.000000,708.000000 684.000000,683.000000 709.000000,683.000000 709.000000,708.000000 709.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 684.000000 708.000000" to="3490.224000 684.000000 708.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,683.000000 659.000000,691.333333 659.000000,699.666667 659.000000,708.000000 659.000000,716.333333 659.000000,724.666667 659.000000,733.000000 667.333333,733.000000 667.333333,724.666667 667.333333,708.000000 667.333333,699.666667 667.333333,691.333333 667.333333,683.000000 675.666667,683.000000 675.666667,691.333333 675.666667,699.666667 675.666667,708.000000 675.666667,716.333333 675.666667,733.000000 684.000000,733.000000 684.000000,724.666667 684.000000,716.333333 684.000000,708.000000 684.000000,699.666667 684.000000,691.333333 684.000000,683.000000 692.333333,691.333333 692.333333,699.666667 692.333333,708.000000 692.333333,716.333333 692.333333,724.666667 692.333333,733.000000 700.666667,733.000000 700.666667,724.666667 700.666667,716.333333 700.666667,699.666667 700.666667,691.333333 700.666667,683.000000 709.000000,683.000000 709.000000,691.333333 709.000000,699.666667 709.000000,708.000000 709.000000,716.333333 709.000000,733.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">126</text>
+  <circle cx="772.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-9.690000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 772.000000 708.000000" to="635.016000 772.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,683.000000 747.000000,733.000000 797.000000,733.000000 797.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 772.000000 708.000000" to="465.048000 772.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,683.000000 747.000000,708.000000 747.000000,733.000000 772.000000,733.000000 772.000000,708.000000 772.000000,683.000000 797.000000,683.000000 797.000000,708.000000 797.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 772.000000 708.000000" to="3490.224000 772.000000 708.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,683.000000 747.000000,691.333333 747.000000,699.666667 747.000000,708.000000 747.000000,716.333333 747.000000,724.666667 747.000000,733.000000 755.333333,733.000000 755.333333,724.666667 755.333333,708.000000 755.333333,699.666667 755.333333,691.333333 755.333333,683.000000 763.666667,683.000000 763.666667,691.333333 763.666667,699.666667 763.666667,708.000000 763.666667,716.333333 763.666667,733.000000 772.000000,733.000000 772.000000,724.666667 772.000000,716.333333 772.000000,708.000000 772.000000,699.666667 772.000000,691.333333 772.000000,683.000000 780.333333,691.333333 780.333333,699.666667 780.333333,708.000000 780.333333,716.333333 780.333333,724.666667 780.333333,733.000000 788.666667,733.000000 788.666667,724.666667 788.666667,716.333333 788.666667,699.666667 788.666667,691.333333 788.666667,683.000000 797.000000,683.000000 797.000000,691.333333 797.000000,699.666667 797.000000,708.000000 797.000000,716.333333 797.000000,733.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="772.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">84</text>
+  <circle cx="860.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-9.880000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 860.000000 708.000000" to="635.016000 860.000000 708.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,683.000000 835.000000,733.000000 885.000000,733.000000 885.000000,683.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 860.000000 708.000000" to="465.048000 860.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,683.000000 835.000000,708.000000 835.000000,733.000000 860.000000,733.000000 860.000000,708.000000 860.000000,683.000000 885.000000,683.000000 885.000000,708.000000 885.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="860.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">36</text>
+  <circle cx="948.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(2337.636000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-10.070000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 948.000000 708.000000" to="465.048000 948.000000 708.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,683.000000 923.000000,708.000000 923.000000,733.000000 948.000000,733.000000 948.000000,708.000000 948.000000,683.000000 973.000000,683.000000 973.000000,708.000000 973.000000,733.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="948.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">9</text>
+  <circle cx="1036.000000" cy="708.000000" r="27.000000" fill="#05050c" stroke="hsl(2475.144000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-10.260000s" repeatCount="indefinite"/>
+  </g>
+  <text x="1036.000000" y="680.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="200.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(1375.080000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-10.450000s" repeatCount="indefinite"/>
+  </g>
+  <text x="200.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="288.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-10.640000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 288.000000 770.000000" to="635.016000 288.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="263.000000,745.000000 263.000000,795.000000 313.000000,795.000000 313.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 288.000000 770.000000" to="2422.620000 288.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="263.000000,745.000000 263.000000,757.500000 263.000000,770.000000 263.000000,782.500000 263.000000,795.000000 275.500000,795.000000 275.500000,782.500000 275.500000,770.000000 275.500000,757.500000 275.500000,745.000000 288.000000,745.000000 288.000000,757.500000 288.000000,770.000000 288.000000,782.500000 288.000000,795.000000 300.500000,795.000000 300.500000,782.500000 300.500000,770.000000 300.500000,757.500000 300.500000,745.000000 313.000000,745.000000 313.000000,757.500000 313.000000,770.000000 313.000000,782.500000 313.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="288.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">10</text>
+  <circle cx="376.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-10.830000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 376.000000 770.000000" to="465.048000 376.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,745.000000 351.000000,770.000000 351.000000,795.000000 376.000000,795.000000 376.000000,770.000000 376.000000,745.000000 401.000000,745.000000 401.000000,770.000000 401.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 376.000000 770.000000" to="2422.620000 376.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,745.000000 351.000000,757.500000 351.000000,770.000000 351.000000,782.500000 351.000000,795.000000 363.500000,795.000000 363.500000,782.500000 363.500000,770.000000 363.500000,757.500000 363.500000,745.000000 376.000000,745.000000 376.000000,757.500000 376.000000,770.000000 376.000000,782.500000 376.000000,795.000000 388.500000,795.000000 388.500000,782.500000 388.500000,770.000000 388.500000,757.500000 388.500000,745.000000 401.000000,745.000000 401.000000,757.500000 401.000000,770.000000 401.000000,782.500000 401.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="376.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">45</text>
+  <circle cx="464.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.020000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 464.000000 770.000000" to="635.016000 464.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,745.000000 455.666667,745.000000 455.666667,761.666667 439.000000,761.666667 439.000000,778.333333 439.000000,795.000000 455.666667,795.000000 455.666667,778.333333 472.333333,778.333333 472.333333,795.000000 489.000000,795.000000 489.000000,778.333333 489.000000,761.666667 472.333333,761.666667 472.333333,745.000000 489.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 464.000000 770.000000" to="465.048000 464.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,745.000000 439.000000,770.000000 439.000000,795.000000 464.000000,795.000000 464.000000,770.000000 464.000000,745.000000 489.000000,745.000000 489.000000,770.000000 489.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 464.000000 770.000000" to="2422.620000 464.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,745.000000 439.000000,757.500000 439.000000,770.000000 439.000000,782.500000 439.000000,795.000000 451.500000,795.000000 451.500000,782.500000 451.500000,770.000000 451.500000,757.500000 451.500000,745.000000 464.000000,745.000000 464.000000,757.500000 464.000000,770.000000 464.000000,782.500000 464.000000,795.000000 476.500000,795.000000 476.500000,782.500000 476.500000,770.000000 476.500000,757.500000 476.500000,745.000000 489.000000,745.000000 489.000000,757.500000 489.000000,770.000000 489.000000,782.500000 489.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="464.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">120</text>
+  <circle cx="552.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.210000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 552.000000 770.000000" to="635.016000 552.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,745.000000 527.000000,795.000000 577.000000,795.000000 577.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 552.000000 770.000000" to="465.048000 552.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,745.000000 527.000000,770.000000 527.000000,795.000000 552.000000,795.000000 552.000000,770.000000 552.000000,745.000000 577.000000,745.000000 577.000000,770.000000 577.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 552.000000 770.000000" to="2422.620000 552.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,745.000000 527.000000,757.500000 527.000000,770.000000 527.000000,782.500000 527.000000,795.000000 539.500000,795.000000 539.500000,782.500000 539.500000,770.000000 539.500000,757.500000 539.500000,745.000000 552.000000,745.000000 552.000000,757.500000 552.000000,770.000000 552.000000,782.500000 552.000000,795.000000 564.500000,795.000000 564.500000,782.500000 564.500000,770.000000 564.500000,757.500000 564.500000,745.000000 577.000000,745.000000 577.000000,757.500000 577.000000,770.000000 577.000000,782.500000 577.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 552.000000 770.000000" to="3490.224000 552.000000 770.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,745.000000 527.000000,753.333333 527.000000,761.666667 527.000000,770.000000 527.000000,778.333333 527.000000,786.666667 527.000000,795.000000 535.333333,795.000000 535.333333,786.666667 535.333333,770.000000 535.333333,761.666667 535.333333,753.333333 535.333333,745.000000 543.666667,745.000000 543.666667,753.333333 543.666667,761.666667 543.666667,770.000000 543.666667,778.333333 543.666667,795.000000 552.000000,795.000000 552.000000,786.666667 552.000000,778.333333 552.000000,770.000000 552.000000,761.666667 552.000000,753.333333 552.000000,745.000000 560.333333,753.333333 560.333333,761.666667 560.333333,770.000000 560.333333,778.333333 560.333333,786.666667 560.333333,795.000000 568.666667,795.000000 568.666667,786.666667 568.666667,778.333333 568.666667,761.666667 568.666667,753.333333 568.666667,745.000000 577.000000,745.000000 577.000000,753.333333 577.000000,761.666667 577.000000,770.000000 577.000000,778.333333 577.000000,795.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="552.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">210</text>
+  <circle cx="640.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.400000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 770.000000" to="635.016000 640.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,745.000000 615.000000,795.000000 665.000000,795.000000 665.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 640.000000 770.000000" to="465.048000 640.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,745.000000 615.000000,770.000000 615.000000,795.000000 640.000000,795.000000 640.000000,770.000000 640.000000,745.000000 665.000000,745.000000 665.000000,770.000000 665.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 640.000000 770.000000" to="3490.224000 640.000000 770.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,745.000000 615.000000,753.333333 615.000000,761.666667 615.000000,770.000000 615.000000,778.333333 615.000000,786.666667 615.000000,795.000000 623.333333,795.000000 623.333333,786.666667 623.333333,770.000000 623.333333,761.666667 623.333333,753.333333 623.333333,745.000000 631.666667,745.000000 631.666667,753.333333 631.666667,761.666667 631.666667,770.000000 631.666667,778.333333 631.666667,795.000000 640.000000,795.000000 640.000000,786.666667 640.000000,778.333333 640.000000,770.000000 640.000000,761.666667 640.000000,753.333333 640.000000,745.000000 648.333333,753.333333 648.333333,761.666667 648.333333,770.000000 648.333333,778.333333 648.333333,786.666667 648.333333,795.000000 656.666667,795.000000 656.666667,786.666667 656.666667,778.333333 656.666667,761.666667 656.666667,753.333333 656.666667,745.000000 665.000000,745.000000 665.000000,753.333333 665.000000,761.666667 665.000000,770.000000 665.000000,778.333333 665.000000,795.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">252</text>
+  <circle cx="728.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.590000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 728.000000 770.000000" to="635.016000 728.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,745.000000 703.000000,795.000000 753.000000,795.000000 753.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 728.000000 770.000000" to="465.048000 728.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,745.000000 703.000000,770.000000 703.000000,795.000000 728.000000,795.000000 728.000000,770.000000 728.000000,745.000000 753.000000,745.000000 753.000000,770.000000 753.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 728.000000 770.000000" to="2422.620000 728.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,745.000000 703.000000,757.500000 703.000000,770.000000 703.000000,782.500000 703.000000,795.000000 715.500000,795.000000 715.500000,782.500000 715.500000,770.000000 715.500000,757.500000 715.500000,745.000000 728.000000,745.000000 728.000000,757.500000 728.000000,770.000000 728.000000,782.500000 728.000000,795.000000 740.500000,795.000000 740.500000,782.500000 740.500000,770.000000 740.500000,757.500000 740.500000,745.000000 753.000000,745.000000 753.000000,757.500000 753.000000,770.000000 753.000000,782.500000 753.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 728.000000 770.000000" to="3490.224000 728.000000 770.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,745.000000 703.000000,753.333333 703.000000,761.666667 703.000000,770.000000 703.000000,778.333333 703.000000,786.666667 703.000000,795.000000 711.333333,795.000000 711.333333,786.666667 711.333333,770.000000 711.333333,761.666667 711.333333,753.333333 711.333333,745.000000 719.666667,745.000000 719.666667,753.333333 719.666667,761.666667 719.666667,770.000000 719.666667,778.333333 719.666667,795.000000 728.000000,795.000000 728.000000,786.666667 728.000000,778.333333 728.000000,770.000000 728.000000,761.666667 728.000000,753.333333 728.000000,745.000000 736.333333,753.333333 736.333333,761.666667 736.333333,770.000000 736.333333,778.333333 736.333333,786.666667 736.333333,795.000000 744.666667,795.000000 744.666667,786.666667 744.666667,778.333333 744.666667,761.666667 744.666667,753.333333 744.666667,745.000000 753.000000,745.000000 753.000000,753.333333 753.000000,761.666667 753.000000,770.000000 753.000000,778.333333 753.000000,795.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="728.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">210</text>
+  <circle cx="816.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2337.636000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.780000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 816.000000 770.000000" to="635.016000 816.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,745.000000 807.666667,745.000000 807.666667,761.666667 791.000000,761.666667 791.000000,778.333333 791.000000,795.000000 807.666667,795.000000 807.666667,778.333333 824.333333,778.333333 824.333333,795.000000 841.000000,795.000000 841.000000,778.333333 841.000000,761.666667 824.333333,761.666667 824.333333,745.000000 841.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 816.000000 770.000000" to="465.048000 816.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,745.000000 791.000000,770.000000 791.000000,795.000000 816.000000,795.000000 816.000000,770.000000 816.000000,745.000000 841.000000,745.000000 841.000000,770.000000 841.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 816.000000 770.000000" to="2422.620000 816.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,745.000000 791.000000,757.500000 791.000000,770.000000 791.000000,782.500000 791.000000,795.000000 803.500000,795.000000 803.500000,782.500000 803.500000,770.000000 803.500000,757.500000 803.500000,745.000000 816.000000,745.000000 816.000000,757.500000 816.000000,770.000000 816.000000,782.500000 816.000000,795.000000 828.500000,795.000000 828.500000,782.500000 828.500000,770.000000 828.500000,757.500000 828.500000,745.000000 841.000000,745.000000 841.000000,757.500000 841.000000,770.000000 841.000000,782.500000 841.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="816.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">120</text>
+  <circle cx="904.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2475.144000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-11.970000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 904.000000 770.000000" to="465.048000 904.000000 770.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,745.000000 879.000000,770.000000 879.000000,795.000000 904.000000,795.000000 904.000000,770.000000 904.000000,745.000000 929.000000,745.000000 929.000000,770.000000 929.000000,795.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 904.000000 770.000000" to="2422.620000 904.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,745.000000 879.000000,757.500000 879.000000,770.000000 879.000000,782.500000 879.000000,795.000000 891.500000,795.000000 891.500000,782.500000 891.500000,770.000000 891.500000,757.500000 891.500000,745.000000 904.000000,745.000000 904.000000,757.500000 904.000000,770.000000 904.000000,782.500000 904.000000,795.000000 916.500000,795.000000 916.500000,782.500000 916.500000,770.000000 916.500000,757.500000 916.500000,745.000000 929.000000,745.000000 929.000000,757.500000 929.000000,770.000000 929.000000,782.500000 929.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="904.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">45</text>
+  <circle cx="992.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2612.652000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-12.160000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 992.000000 770.000000" to="635.016000 992.000000 770.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="967.000000,745.000000 967.000000,795.000000 1017.000000,795.000000 1017.000000,745.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 992.000000 770.000000" to="2422.620000 992.000000 770.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="967.000000,745.000000 967.000000,757.500000 967.000000,770.000000 967.000000,782.500000 967.000000,795.000000 979.500000,795.000000 979.500000,782.500000 979.500000,770.000000 979.500000,757.500000 979.500000,745.000000 992.000000,745.000000 992.000000,757.500000 992.000000,770.000000 992.000000,782.500000 992.000000,795.000000 1004.500000,795.000000 1004.500000,782.500000 1004.500000,770.000000 1004.500000,757.500000 1004.500000,745.000000 1017.000000,745.000000 1017.000000,757.500000 1017.000000,770.000000 1017.000000,782.500000 1017.000000,795.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="992.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">10</text>
+  <circle cx="1080.000000" cy="770.000000" r="27.000000" fill="#05050c" stroke="hsl(2750.160000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-12.350000s" repeatCount="indefinite"/>
+  </g>
+  <text x="1080.000000" y="742.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="156.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(1512.588000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-12.540000s" repeatCount="indefinite"/>
+  </g>
+  <text x="156.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="244.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-12.730000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 244.000000 832.000000" to="7922.940000 244.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="219.000000,807.000000 219.000000,817.000000 219.000000,832.000000 219.000000,847.000000 224.000000,857.000000 224.000000,847.000000 224.000000,832.000000 224.000000,817.000000 229.000000,807.000000 229.000000,822.000000 229.000000,832.000000 229.000000,847.000000 234.000000,857.000000 234.000000,842.000000 234.000000,827.000000 234.000000,817.000000 239.000000,807.000000 239.000000,822.000000 239.000000,837.000000 239.000000,852.000000 244.000000,857.000000 244.000000,842.000000 244.000000,827.000000 244.000000,812.000000 249.000000,807.000000 249.000000,822.000000 249.000000,837.000000 249.000000,852.000000 254.000000,852.000000 254.000000,842.000000 254.000000,827.000000 254.000000,812.000000 259.000000,812.000000 259.000000,827.000000 259.000000,837.000000 259.000000,852.000000 264.000000,852.000000 264.000000,837.000000 264.000000,822.000000 264.000000,812.000000 269.000000,812.000000 269.000000,827.000000 269.000000,842.000000 269.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="244.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">11</text>
+  <circle cx="332.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-12.920000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 332.000000 832.000000" to="2422.620000 332.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,807.000000 307.000000,819.500000 307.000000,832.000000 307.000000,844.500000 307.000000,857.000000 319.500000,857.000000 319.500000,844.500000 319.500000,832.000000 319.500000,819.500000 319.500000,807.000000 332.000000,807.000000 332.000000,819.500000 332.000000,832.000000 332.000000,844.500000 332.000000,857.000000 344.500000,857.000000 344.500000,844.500000 344.500000,832.000000 344.500000,819.500000 344.500000,807.000000 357.000000,807.000000 357.000000,819.500000 357.000000,832.000000 357.000000,844.500000 357.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 332.000000 832.000000" to="7922.940000 332.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,807.000000 307.000000,817.000000 307.000000,832.000000 307.000000,847.000000 312.000000,857.000000 312.000000,847.000000 312.000000,832.000000 312.000000,817.000000 317.000000,807.000000 317.000000,822.000000 317.000000,832.000000 317.000000,847.000000 322.000000,857.000000 322.000000,842.000000 322.000000,827.000000 322.000000,817.000000 327.000000,807.000000 327.000000,822.000000 327.000000,837.000000 327.000000,852.000000 332.000000,857.000000 332.000000,842.000000 332.000000,827.000000 332.000000,812.000000 337.000000,807.000000 337.000000,822.000000 337.000000,837.000000 337.000000,852.000000 342.000000,852.000000 342.000000,842.000000 342.000000,827.000000 342.000000,812.000000 347.000000,812.000000 347.000000,827.000000 347.000000,837.000000 347.000000,852.000000 352.000000,852.000000 352.000000,837.000000 352.000000,822.000000 352.000000,812.000000 357.000000,812.000000 357.000000,827.000000 357.000000,842.000000 357.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="332.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">55</text>
+  <circle cx="420.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-13.110000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 420.000000 832.000000" to="465.048000 420.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,807.000000 395.000000,832.000000 395.000000,857.000000 420.000000,857.000000 420.000000,832.000000 420.000000,807.000000 445.000000,807.000000 445.000000,832.000000 445.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 420.000000 832.000000" to="2422.620000 420.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,807.000000 395.000000,819.500000 395.000000,832.000000 395.000000,844.500000 395.000000,857.000000 407.500000,857.000000 407.500000,844.500000 407.500000,832.000000 407.500000,819.500000 407.500000,807.000000 420.000000,807.000000 420.000000,819.500000 420.000000,832.000000 420.000000,844.500000 420.000000,857.000000 432.500000,857.000000 432.500000,844.500000 432.500000,832.000000 432.500000,819.500000 432.500000,807.000000 445.000000,807.000000 445.000000,819.500000 445.000000,832.000000 445.000000,844.500000 445.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 420.000000 832.000000" to="7922.940000 420.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,807.000000 395.000000,817.000000 395.000000,832.000000 395.000000,847.000000 400.000000,857.000000 400.000000,847.000000 400.000000,832.000000 400.000000,817.000000 405.000000,807.000000 405.000000,822.000000 405.000000,832.000000 405.000000,847.000000 410.000000,857.000000 410.000000,842.000000 410.000000,827.000000 410.000000,817.000000 415.000000,807.000000 415.000000,822.000000 415.000000,837.000000 415.000000,852.000000 420.000000,857.000000 420.000000,842.000000 420.000000,827.000000 420.000000,812.000000 425.000000,807.000000 425.000000,822.000000 425.000000,837.000000 425.000000,852.000000 430.000000,852.000000 430.000000,842.000000 430.000000,827.000000 430.000000,812.000000 435.000000,812.000000 435.000000,827.000000 435.000000,837.000000 435.000000,852.000000 440.000000,852.000000 440.000000,837.000000 440.000000,822.000000 440.000000,812.000000 445.000000,812.000000 445.000000,827.000000 445.000000,842.000000 445.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="420.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">165</text>
+  <circle cx="508.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-13.300000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 508.000000 832.000000" to="635.016000 508.000000 832.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,807.000000 483.000000,857.000000 533.000000,857.000000 533.000000,807.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 508.000000 832.000000" to="465.048000 508.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,807.000000 483.000000,832.000000 483.000000,857.000000 508.000000,857.000000 508.000000,832.000000 508.000000,807.000000 533.000000,807.000000 533.000000,832.000000 533.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 508.000000 832.000000" to="2422.620000 508.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,807.000000 483.000000,819.500000 483.000000,832.000000 483.000000,844.500000 483.000000,857.000000 495.500000,857.000000 495.500000,844.500000 495.500000,832.000000 495.500000,819.500000 495.500000,807.000000 508.000000,807.000000 508.000000,819.500000 508.000000,832.000000 508.000000,844.500000 508.000000,857.000000 520.500000,857.000000 520.500000,844.500000 520.500000,832.000000 520.500000,819.500000 520.500000,807.000000 533.000000,807.000000 533.000000,819.500000 533.000000,832.000000 533.000000,844.500000 533.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 508.000000 832.000000" to="7922.940000 508.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,807.000000 483.000000,817.000000 483.000000,832.000000 483.000000,847.000000 488.000000,857.000000 488.000000,847.000000 488.000000,832.000000 488.000000,817.000000 493.000000,807.000000 493.000000,822.000000 493.000000,832.000000 493.000000,847.000000 498.000000,857.000000 498.000000,842.000000 498.000000,827.000000 498.000000,817.000000 503.000000,807.000000 503.000000,822.000000 503.000000,837.000000 503.000000,852.000000 508.000000,857.000000 508.000000,842.000000 508.000000,827.000000 508.000000,812.000000 513.000000,807.000000 513.000000,822.000000 513.000000,837.000000 513.000000,852.000000 518.000000,852.000000 518.000000,842.000000 518.000000,827.000000 518.000000,812.000000 523.000000,812.000000 523.000000,827.000000 523.000000,837.000000 523.000000,852.000000 528.000000,852.000000 528.000000,837.000000 528.000000,822.000000 528.000000,812.000000 533.000000,812.000000 533.000000,827.000000 533.000000,842.000000 533.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="508.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">330</text>
+  <circle cx="596.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-13.490000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 596.000000 832.000000" to="635.016000 596.000000 832.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,807.000000 571.000000,857.000000 621.000000,857.000000 621.000000,807.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 596.000000 832.000000" to="465.048000 596.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,807.000000 571.000000,832.000000 571.000000,857.000000 596.000000,857.000000 596.000000,832.000000 596.000000,807.000000 621.000000,807.000000 621.000000,832.000000 621.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 596.000000 832.000000" to="3490.224000 596.000000 832.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,807.000000 571.000000,815.333333 571.000000,823.666667 571.000000,832.000000 571.000000,840.333333 571.000000,848.666667 571.000000,857.000000 579.333333,857.000000 579.333333,848.666667 579.333333,832.000000 579.333333,823.666667 579.333333,815.333333 579.333333,807.000000 587.666667,807.000000 587.666667,815.333333 587.666667,823.666667 587.666667,832.000000 587.666667,840.333333 587.666667,857.000000 596.000000,857.000000 596.000000,848.666667 596.000000,840.333333 596.000000,832.000000 596.000000,823.666667 596.000000,815.333333 596.000000,807.000000 604.333333,815.333333 604.333333,823.666667 604.333333,832.000000 604.333333,840.333333 604.333333,848.666667 604.333333,857.000000 612.666667,857.000000 612.666667,848.666667 612.666667,840.333333 612.666667,823.666667 612.666667,815.333333 612.666667,807.000000 621.000000,807.000000 621.000000,815.333333 621.000000,823.666667 621.000000,832.000000 621.000000,840.333333 621.000000,857.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 596.000000 832.000000" to="7922.940000 596.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,807.000000 571.000000,817.000000 571.000000,832.000000 571.000000,847.000000 576.000000,857.000000 576.000000,847.000000 576.000000,832.000000 576.000000,817.000000 581.000000,807.000000 581.000000,822.000000 581.000000,832.000000 581.000000,847.000000 586.000000,857.000000 586.000000,842.000000 586.000000,827.000000 586.000000,817.000000 591.000000,807.000000 591.000000,822.000000 591.000000,837.000000 591.000000,852.000000 596.000000,857.000000 596.000000,842.000000 596.000000,827.000000 596.000000,812.000000 601.000000,807.000000 601.000000,822.000000 601.000000,837.000000 601.000000,852.000000 606.000000,852.000000 606.000000,842.000000 606.000000,827.000000 606.000000,812.000000 611.000000,812.000000 611.000000,827.000000 611.000000,837.000000 611.000000,852.000000 616.000000,852.000000 616.000000,837.000000 616.000000,822.000000 616.000000,812.000000 621.000000,812.000000 621.000000,827.000000 621.000000,842.000000 621.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">462</text>
+  <circle cx="684.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2337.636000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-13.680000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 684.000000 832.000000" to="635.016000 684.000000 832.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,807.000000 659.000000,857.000000 709.000000,857.000000 709.000000,807.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 684.000000 832.000000" to="465.048000 684.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,807.000000 659.000000,832.000000 659.000000,857.000000 684.000000,857.000000 684.000000,832.000000 684.000000,807.000000 709.000000,807.000000 709.000000,832.000000 709.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 684.000000 832.000000" to="3490.224000 684.000000 832.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,807.000000 659.000000,815.333333 659.000000,823.666667 659.000000,832.000000 659.000000,840.333333 659.000000,848.666667 659.000000,857.000000 667.333333,857.000000 667.333333,848.666667 667.333333,832.000000 667.333333,823.666667 667.333333,815.333333 667.333333,807.000000 675.666667,807.000000 675.666667,815.333333 675.666667,823.666667 675.666667,832.000000 675.666667,840.333333 675.666667,857.000000 684.000000,857.000000 684.000000,848.666667 684.000000,840.333333 684.000000,832.000000 684.000000,823.666667 684.000000,815.333333 684.000000,807.000000 692.333333,815.333333 692.333333,823.666667 692.333333,832.000000 692.333333,840.333333 692.333333,848.666667 692.333333,857.000000 700.666667,857.000000 700.666667,848.666667 700.666667,840.333333 700.666667,823.666667 700.666667,815.333333 700.666667,807.000000 709.000000,807.000000 709.000000,815.333333 709.000000,823.666667 709.000000,832.000000 709.000000,840.333333 709.000000,857.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 684.000000 832.000000" to="7922.940000 684.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,807.000000 659.000000,817.000000 659.000000,832.000000 659.000000,847.000000 664.000000,857.000000 664.000000,847.000000 664.000000,832.000000 664.000000,817.000000 669.000000,807.000000 669.000000,822.000000 669.000000,832.000000 669.000000,847.000000 674.000000,857.000000 674.000000,842.000000 674.000000,827.000000 674.000000,817.000000 679.000000,807.000000 679.000000,822.000000 679.000000,837.000000 679.000000,852.000000 684.000000,857.000000 684.000000,842.000000 684.000000,827.000000 684.000000,812.000000 689.000000,807.000000 689.000000,822.000000 689.000000,837.000000 689.000000,852.000000 694.000000,852.000000 694.000000,842.000000 694.000000,827.000000 694.000000,812.000000 699.000000,812.000000 699.000000,827.000000 699.000000,837.000000 699.000000,852.000000 704.000000,852.000000 704.000000,837.000000 704.000000,822.000000 704.000000,812.000000 709.000000,812.000000 709.000000,827.000000 709.000000,842.000000 709.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">462</text>
+  <circle cx="772.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2475.144000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-13.870000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 772.000000 832.000000" to="635.016000 772.000000 832.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,807.000000 747.000000,857.000000 797.000000,857.000000 797.000000,807.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 772.000000 832.000000" to="465.048000 772.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,807.000000 747.000000,832.000000 747.000000,857.000000 772.000000,857.000000 772.000000,832.000000 772.000000,807.000000 797.000000,807.000000 797.000000,832.000000 797.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 772.000000 832.000000" to="2422.620000 772.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,807.000000 747.000000,819.500000 747.000000,832.000000 747.000000,844.500000 747.000000,857.000000 759.500000,857.000000 759.500000,844.500000 759.500000,832.000000 759.500000,819.500000 759.500000,807.000000 772.000000,807.000000 772.000000,819.500000 772.000000,832.000000 772.000000,844.500000 772.000000,857.000000 784.500000,857.000000 784.500000,844.500000 784.500000,832.000000 784.500000,819.500000 784.500000,807.000000 797.000000,807.000000 797.000000,819.500000 797.000000,832.000000 797.000000,844.500000 797.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 772.000000 832.000000" to="7922.940000 772.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,807.000000 747.000000,817.000000 747.000000,832.000000 747.000000,847.000000 752.000000,857.000000 752.000000,847.000000 752.000000,832.000000 752.000000,817.000000 757.000000,807.000000 757.000000,822.000000 757.000000,832.000000 757.000000,847.000000 762.000000,857.000000 762.000000,842.000000 762.000000,827.000000 762.000000,817.000000 767.000000,807.000000 767.000000,822.000000 767.000000,837.000000 767.000000,852.000000 772.000000,857.000000 772.000000,842.000000 772.000000,827.000000 772.000000,812.000000 777.000000,807.000000 777.000000,822.000000 777.000000,837.000000 777.000000,852.000000 782.000000,852.000000 782.000000,842.000000 782.000000,827.000000 782.000000,812.000000 787.000000,812.000000 787.000000,827.000000 787.000000,837.000000 787.000000,852.000000 792.000000,852.000000 792.000000,837.000000 792.000000,822.000000 792.000000,812.000000 797.000000,812.000000 797.000000,827.000000 797.000000,842.000000 797.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="772.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">330</text>
+  <circle cx="860.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2612.652000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-14.060000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 860.000000 832.000000" to="465.048000 860.000000 832.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,807.000000 835.000000,832.000000 835.000000,857.000000 860.000000,857.000000 860.000000,832.000000 860.000000,807.000000 885.000000,807.000000 885.000000,832.000000 885.000000,857.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 860.000000 832.000000" to="2422.620000 860.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,807.000000 835.000000,819.500000 835.000000,832.000000 835.000000,844.500000 835.000000,857.000000 847.500000,857.000000 847.500000,844.500000 847.500000,832.000000 847.500000,819.500000 847.500000,807.000000 860.000000,807.000000 860.000000,819.500000 860.000000,832.000000 860.000000,844.500000 860.000000,857.000000 872.500000,857.000000 872.500000,844.500000 872.500000,832.000000 872.500000,819.500000 872.500000,807.000000 885.000000,807.000000 885.000000,819.500000 885.000000,832.000000 885.000000,844.500000 885.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 860.000000 832.000000" to="7922.940000 860.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,807.000000 835.000000,817.000000 835.000000,832.000000 835.000000,847.000000 840.000000,857.000000 840.000000,847.000000 840.000000,832.000000 840.000000,817.000000 845.000000,807.000000 845.000000,822.000000 845.000000,832.000000 845.000000,847.000000 850.000000,857.000000 850.000000,842.000000 850.000000,827.000000 850.000000,817.000000 855.000000,807.000000 855.000000,822.000000 855.000000,837.000000 855.000000,852.000000 860.000000,857.000000 860.000000,842.000000 860.000000,827.000000 860.000000,812.000000 865.000000,807.000000 865.000000,822.000000 865.000000,837.000000 865.000000,852.000000 870.000000,852.000000 870.000000,842.000000 870.000000,827.000000 870.000000,812.000000 875.000000,812.000000 875.000000,827.000000 875.000000,837.000000 875.000000,852.000000 880.000000,852.000000 880.000000,837.000000 880.000000,822.000000 880.000000,812.000000 885.000000,812.000000 885.000000,827.000000 885.000000,842.000000 885.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="860.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">165</text>
+  <circle cx="948.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2750.160000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-14.250000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 948.000000 832.000000" to="2422.620000 948.000000 832.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,807.000000 923.000000,819.500000 923.000000,832.000000 923.000000,844.500000 923.000000,857.000000 935.500000,857.000000 935.500000,844.500000 935.500000,832.000000 935.500000,819.500000 935.500000,807.000000 948.000000,807.000000 948.000000,819.500000 948.000000,832.000000 948.000000,844.500000 948.000000,857.000000 960.500000,857.000000 960.500000,844.500000 960.500000,832.000000 960.500000,819.500000 960.500000,807.000000 973.000000,807.000000 973.000000,819.500000 973.000000,832.000000 973.000000,844.500000 973.000000,857.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 948.000000 832.000000" to="7922.940000 948.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,807.000000 923.000000,817.000000 923.000000,832.000000 923.000000,847.000000 928.000000,857.000000 928.000000,847.000000 928.000000,832.000000 928.000000,817.000000 933.000000,807.000000 933.000000,822.000000 933.000000,832.000000 933.000000,847.000000 938.000000,857.000000 938.000000,842.000000 938.000000,827.000000 938.000000,817.000000 943.000000,807.000000 943.000000,822.000000 943.000000,837.000000 943.000000,852.000000 948.000000,857.000000 948.000000,842.000000 948.000000,827.000000 948.000000,812.000000 953.000000,807.000000 953.000000,822.000000 953.000000,837.000000 953.000000,852.000000 958.000000,852.000000 958.000000,842.000000 958.000000,827.000000 958.000000,812.000000 963.000000,812.000000 963.000000,827.000000 963.000000,837.000000 963.000000,852.000000 968.000000,852.000000 968.000000,837.000000 968.000000,822.000000 968.000000,812.000000 973.000000,812.000000 973.000000,827.000000 973.000000,842.000000 973.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="948.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">55</text>
+  <circle cx="1036.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(2887.668000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-14.440000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 1036.000000 832.000000" to="7922.940000 1036.000000 832.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="1011.000000,807.000000 1011.000000,817.000000 1011.000000,832.000000 1011.000000,847.000000 1016.000000,857.000000 1016.000000,847.000000 1016.000000,832.000000 1016.000000,817.000000 1021.000000,807.000000 1021.000000,822.000000 1021.000000,832.000000 1021.000000,847.000000 1026.000000,857.000000 1026.000000,842.000000 1026.000000,827.000000 1026.000000,817.000000 1031.000000,807.000000 1031.000000,822.000000 1031.000000,837.000000 1031.000000,852.000000 1036.000000,857.000000 1036.000000,842.000000 1036.000000,827.000000 1036.000000,812.000000 1041.000000,807.000000 1041.000000,822.000000 1041.000000,837.000000 1041.000000,852.000000 1046.000000,852.000000 1046.000000,842.000000 1046.000000,827.000000 1046.000000,812.000000 1051.000000,812.000000 1051.000000,827.000000 1051.000000,837.000000 1051.000000,852.000000 1056.000000,852.000000 1056.000000,837.000000 1056.000000,822.000000 1056.000000,812.000000 1061.000000,812.000000 1061.000000,827.000000 1061.000000,842.000000 1061.000000,857.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="1036.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">11</text>
+  <circle cx="1124.000000" cy="832.000000" r="27.000000" fill="#05050c" stroke="hsl(3025.176000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-14.630000s" repeatCount="indefinite"/>
+  </g>
+  <text x="1124.000000" y="804.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="112.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(1650.096000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-14.820000s" repeatCount="indefinite"/>
+  </g>
+  <text x="112.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="200.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.010000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 200.000000 894.000000" to="635.016000 200.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="175.000000,869.000000 175.000000,919.000000 225.000000,919.000000 225.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 200.000000 894.000000" to="465.048000 200.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="175.000000,869.000000 175.000000,894.000000 175.000000,919.000000 200.000000,919.000000 200.000000,894.000000 200.000000,869.000000 225.000000,869.000000 225.000000,894.000000 225.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="200.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">12</text>
+  <circle cx="288.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.200000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 288.000000 894.000000" to="635.016000 288.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="263.000000,869.000000 263.000000,919.000000 313.000000,919.000000 313.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 288.000000 894.000000" to="465.048000 288.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="263.000000,869.000000 263.000000,894.000000 263.000000,919.000000 288.000000,919.000000 288.000000,894.000000 288.000000,869.000000 313.000000,869.000000 313.000000,894.000000 313.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 288.000000 894.000000" to="7922.940000 288.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="263.000000,869.000000 263.000000,879.000000 263.000000,894.000000 263.000000,909.000000 268.000000,919.000000 268.000000,909.000000 268.000000,894.000000 268.000000,879.000000 273.000000,869.000000 273.000000,884.000000 273.000000,894.000000 273.000000,909.000000 278.000000,919.000000 278.000000,904.000000 278.000000,889.000000 278.000000,879.000000 283.000000,869.000000 283.000000,884.000000 283.000000,899.000000 283.000000,914.000000 288.000000,919.000000 288.000000,904.000000 288.000000,889.000000 288.000000,874.000000 293.000000,869.000000 293.000000,884.000000 293.000000,899.000000 293.000000,914.000000 298.000000,914.000000 298.000000,904.000000 298.000000,889.000000 298.000000,874.000000 303.000000,874.000000 303.000000,889.000000 303.000000,899.000000 303.000000,914.000000 308.000000,914.000000 308.000000,899.000000 308.000000,884.000000 308.000000,874.000000 313.000000,874.000000 313.000000,889.000000 313.000000,904.000000 313.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="288.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">66</text>
+  <circle cx="376.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.390000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 376.000000 894.000000" to="635.016000 376.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,869.000000 351.000000,919.000000 401.000000,919.000000 401.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 376.000000 894.000000" to="2422.620000 376.000000 894.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,869.000000 351.000000,881.500000 351.000000,894.000000 351.000000,906.500000 351.000000,919.000000 363.500000,919.000000 363.500000,906.500000 363.500000,894.000000 363.500000,881.500000 363.500000,869.000000 376.000000,869.000000 376.000000,881.500000 376.000000,894.000000 376.000000,906.500000 376.000000,919.000000 388.500000,919.000000 388.500000,906.500000 388.500000,894.000000 388.500000,881.500000 388.500000,869.000000 401.000000,869.000000 401.000000,881.500000 401.000000,894.000000 401.000000,906.500000 401.000000,919.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 376.000000 894.000000" to="7922.940000 376.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="351.000000,869.000000 351.000000,879.000000 351.000000,894.000000 351.000000,909.000000 356.000000,919.000000 356.000000,909.000000 356.000000,894.000000 356.000000,879.000000 361.000000,869.000000 361.000000,884.000000 361.000000,894.000000 361.000000,909.000000 366.000000,919.000000 366.000000,904.000000 366.000000,889.000000 366.000000,879.000000 371.000000,869.000000 371.000000,884.000000 371.000000,899.000000 371.000000,914.000000 376.000000,919.000000 376.000000,904.000000 376.000000,889.000000 376.000000,874.000000 381.000000,869.000000 381.000000,884.000000 381.000000,899.000000 381.000000,914.000000 386.000000,914.000000 386.000000,904.000000 386.000000,889.000000 386.000000,874.000000 391.000000,874.000000 391.000000,889.000000 391.000000,899.000000 391.000000,914.000000 396.000000,914.000000 396.000000,899.000000 396.000000,884.000000 396.000000,874.000000 401.000000,874.000000 401.000000,889.000000 401.000000,904.000000 401.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="376.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">220</text>
+  <circle cx="464.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.580000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 464.000000 894.000000" to="465.048000 464.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,869.000000 439.000000,894.000000 439.000000,919.000000 464.000000,919.000000 464.000000,894.000000 464.000000,869.000000 489.000000,869.000000 489.000000,894.000000 489.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 464.000000 894.000000" to="2422.620000 464.000000 894.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,869.000000 439.000000,881.500000 439.000000,894.000000 439.000000,906.500000 439.000000,919.000000 451.500000,919.000000 451.500000,906.500000 451.500000,894.000000 451.500000,881.500000 451.500000,869.000000 464.000000,869.000000 464.000000,881.500000 464.000000,894.000000 464.000000,906.500000 464.000000,919.000000 476.500000,919.000000 476.500000,906.500000 476.500000,894.000000 476.500000,881.500000 476.500000,869.000000 489.000000,869.000000 489.000000,881.500000 489.000000,894.000000 489.000000,906.500000 489.000000,919.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 464.000000 894.000000" to="7922.940000 464.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="439.000000,869.000000 439.000000,879.000000 439.000000,894.000000 439.000000,909.000000 444.000000,919.000000 444.000000,909.000000 444.000000,894.000000 444.000000,879.000000 449.000000,869.000000 449.000000,884.000000 449.000000,894.000000 449.000000,909.000000 454.000000,919.000000 454.000000,904.000000 454.000000,889.000000 454.000000,879.000000 459.000000,869.000000 459.000000,884.000000 459.000000,899.000000 459.000000,914.000000 464.000000,919.000000 464.000000,904.000000 464.000000,889.000000 464.000000,874.000000 469.000000,869.000000 469.000000,884.000000 469.000000,899.000000 469.000000,914.000000 474.000000,914.000000 474.000000,904.000000 474.000000,889.000000 474.000000,874.000000 479.000000,874.000000 479.000000,889.000000 479.000000,899.000000 479.000000,914.000000 484.000000,914.000000 484.000000,899.000000 484.000000,884.000000 484.000000,874.000000 489.000000,874.000000 489.000000,889.000000 489.000000,904.000000 489.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="464.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">495</text>
+  <circle cx="552.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2337.636000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.770000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 552.000000 894.000000" to="635.016000 552.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,869.000000 543.666667,869.000000 543.666667,885.666667 527.000000,885.666667 527.000000,902.333333 527.000000,919.000000 543.666667,919.000000 543.666667,902.333333 560.333333,902.333333 560.333333,919.000000 577.000000,919.000000 577.000000,902.333333 577.000000,885.666667 560.333333,885.666667 560.333333,869.000000 577.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 552.000000 894.000000" to="465.048000 552.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,869.000000 527.000000,894.000000 527.000000,919.000000 552.000000,919.000000 552.000000,894.000000 552.000000,869.000000 577.000000,869.000000 577.000000,894.000000 577.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 552.000000 894.000000" to="7922.940000 552.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="527.000000,869.000000 527.000000,879.000000 527.000000,894.000000 527.000000,909.000000 532.000000,919.000000 532.000000,909.000000 532.000000,894.000000 532.000000,879.000000 537.000000,869.000000 537.000000,884.000000 537.000000,894.000000 537.000000,909.000000 542.000000,919.000000 542.000000,904.000000 542.000000,889.000000 542.000000,879.000000 547.000000,869.000000 547.000000,884.000000 547.000000,899.000000 547.000000,914.000000 552.000000,919.000000 552.000000,904.000000 552.000000,889.000000 552.000000,874.000000 557.000000,869.000000 557.000000,884.000000 557.000000,899.000000 557.000000,914.000000 562.000000,914.000000 562.000000,904.000000 562.000000,889.000000 562.000000,874.000000 567.000000,874.000000 567.000000,889.000000 567.000000,899.000000 567.000000,914.000000 572.000000,914.000000 572.000000,899.000000 572.000000,884.000000 572.000000,874.000000 577.000000,874.000000 577.000000,889.000000 577.000000,904.000000 577.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="552.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">792</text>
+  <circle cx="640.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2475.144000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-15.960000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 640.000000 894.000000" to="635.016000 640.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,869.000000 615.000000,919.000000 665.000000,919.000000 665.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 640.000000 894.000000" to="465.048000 640.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,869.000000 615.000000,894.000000 615.000000,919.000000 640.000000,919.000000 640.000000,894.000000 640.000000,869.000000 665.000000,869.000000 665.000000,894.000000 665.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="3850.224000 640.000000 894.000000" to="3490.224000 640.000000 894.000000" dur="24.500000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,869.000000 615.000000,877.333333 615.000000,885.666667 615.000000,894.000000 615.000000,902.333333 615.000000,910.666667 615.000000,919.000000 623.333333,919.000000 623.333333,910.666667 623.333333,894.000000 623.333333,885.666667 623.333333,877.333333 623.333333,869.000000 631.666667,869.000000 631.666667,877.333333 631.666667,885.666667 631.666667,894.000000 631.666667,902.333333 631.666667,919.000000 640.000000,919.000000 640.000000,910.666667 640.000000,902.333333 640.000000,894.000000 640.000000,885.666667 640.000000,877.333333 640.000000,869.000000 648.333333,877.333333 648.333333,885.666667 648.333333,894.000000 648.333333,902.333333 648.333333,910.666667 648.333333,919.000000 656.666667,919.000000 656.666667,910.666667 656.666667,902.333333 656.666667,885.666667 656.666667,877.333333 656.666667,869.000000 665.000000,869.000000 665.000000,877.333333 665.000000,885.666667 665.000000,894.000000 665.000000,902.333333 665.000000,919.000000" fill="none" stroke="#6cff6c" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 640.000000 894.000000" to="7922.940000 640.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="615.000000,869.000000 615.000000,879.000000 615.000000,894.000000 615.000000,909.000000 620.000000,919.000000 620.000000,909.000000 620.000000,894.000000 620.000000,879.000000 625.000000,869.000000 625.000000,884.000000 625.000000,894.000000 625.000000,909.000000 630.000000,919.000000 630.000000,904.000000 630.000000,889.000000 630.000000,879.000000 635.000000,869.000000 635.000000,884.000000 635.000000,899.000000 635.000000,914.000000 640.000000,919.000000 640.000000,904.000000 640.000000,889.000000 640.000000,874.000000 645.000000,869.000000 645.000000,884.000000 645.000000,899.000000 645.000000,914.000000 650.000000,914.000000 650.000000,904.000000 650.000000,889.000000 650.000000,874.000000 655.000000,874.000000 655.000000,889.000000 655.000000,899.000000 655.000000,914.000000 660.000000,914.000000 660.000000,899.000000 660.000000,884.000000 660.000000,874.000000 665.000000,874.000000 665.000000,889.000000 665.000000,904.000000 665.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="640.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">924</text>
+  <circle cx="728.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2612.652000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-16.150000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 728.000000 894.000000" to="635.016000 728.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,869.000000 719.666667,869.000000 719.666667,885.666667 703.000000,885.666667 703.000000,902.333333 703.000000,919.000000 719.666667,919.000000 719.666667,902.333333 736.333333,902.333333 736.333333,919.000000 753.000000,919.000000 753.000000,902.333333 753.000000,885.666667 736.333333,885.666667 736.333333,869.000000 753.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 728.000000 894.000000" to="465.048000 728.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,869.000000 703.000000,894.000000 703.000000,919.000000 728.000000,919.000000 728.000000,894.000000 728.000000,869.000000 753.000000,869.000000 753.000000,894.000000 753.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 728.000000 894.000000" to="7922.940000 728.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="703.000000,869.000000 703.000000,879.000000 703.000000,894.000000 703.000000,909.000000 708.000000,919.000000 708.000000,909.000000 708.000000,894.000000 708.000000,879.000000 713.000000,869.000000 713.000000,884.000000 713.000000,894.000000 713.000000,909.000000 718.000000,919.000000 718.000000,904.000000 718.000000,889.000000 718.000000,879.000000 723.000000,869.000000 723.000000,884.000000 723.000000,899.000000 723.000000,914.000000 728.000000,919.000000 728.000000,904.000000 728.000000,889.000000 728.000000,874.000000 733.000000,869.000000 733.000000,884.000000 733.000000,899.000000 733.000000,914.000000 738.000000,914.000000 738.000000,904.000000 738.000000,889.000000 738.000000,874.000000 743.000000,874.000000 743.000000,889.000000 743.000000,899.000000 743.000000,914.000000 748.000000,914.000000 748.000000,899.000000 748.000000,884.000000 748.000000,874.000000 753.000000,874.000000 753.000000,889.000000 753.000000,904.000000 753.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="728.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">792</text>
+  <circle cx="816.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2750.160000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-16.340000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 816.000000 894.000000" to="465.048000 816.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,869.000000 791.000000,894.000000 791.000000,919.000000 816.000000,919.000000 816.000000,894.000000 816.000000,869.000000 841.000000,869.000000 841.000000,894.000000 841.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 816.000000 894.000000" to="2422.620000 816.000000 894.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,869.000000 791.000000,881.500000 791.000000,894.000000 791.000000,906.500000 791.000000,919.000000 803.500000,919.000000 803.500000,906.500000 803.500000,894.000000 803.500000,881.500000 803.500000,869.000000 816.000000,869.000000 816.000000,881.500000 816.000000,894.000000 816.000000,906.500000 816.000000,919.000000 828.500000,919.000000 828.500000,906.500000 828.500000,894.000000 828.500000,881.500000 828.500000,869.000000 841.000000,869.000000 841.000000,881.500000 841.000000,894.000000 841.000000,906.500000 841.000000,919.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 816.000000 894.000000" to="7922.940000 816.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="791.000000,869.000000 791.000000,879.000000 791.000000,894.000000 791.000000,909.000000 796.000000,919.000000 796.000000,909.000000 796.000000,894.000000 796.000000,879.000000 801.000000,869.000000 801.000000,884.000000 801.000000,894.000000 801.000000,909.000000 806.000000,919.000000 806.000000,904.000000 806.000000,889.000000 806.000000,879.000000 811.000000,869.000000 811.000000,884.000000 811.000000,899.000000 811.000000,914.000000 816.000000,919.000000 816.000000,904.000000 816.000000,889.000000 816.000000,874.000000 821.000000,869.000000 821.000000,884.000000 821.000000,899.000000 821.000000,914.000000 826.000000,914.000000 826.000000,904.000000 826.000000,889.000000 826.000000,874.000000 831.000000,874.000000 831.000000,889.000000 831.000000,899.000000 831.000000,914.000000 836.000000,914.000000 836.000000,899.000000 836.000000,884.000000 836.000000,874.000000 841.000000,874.000000 841.000000,889.000000 841.000000,904.000000 841.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="816.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">495</text>
+  <circle cx="904.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(2887.668000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-16.530000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 904.000000 894.000000" to="635.016000 904.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,869.000000 879.000000,919.000000 929.000000,919.000000 929.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 904.000000 894.000000" to="2422.620000 904.000000 894.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,869.000000 879.000000,881.500000 879.000000,894.000000 879.000000,906.500000 879.000000,919.000000 891.500000,919.000000 891.500000,906.500000 891.500000,894.000000 891.500000,881.500000 891.500000,869.000000 904.000000,869.000000 904.000000,881.500000 904.000000,894.000000 904.000000,906.500000 904.000000,919.000000 916.500000,919.000000 916.500000,906.500000 916.500000,894.000000 916.500000,881.500000 916.500000,869.000000 929.000000,869.000000 929.000000,881.500000 929.000000,894.000000 929.000000,906.500000 929.000000,919.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 904.000000 894.000000" to="7922.940000 904.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="879.000000,869.000000 879.000000,879.000000 879.000000,894.000000 879.000000,909.000000 884.000000,919.000000 884.000000,909.000000 884.000000,894.000000 884.000000,879.000000 889.000000,869.000000 889.000000,884.000000 889.000000,894.000000 889.000000,909.000000 894.000000,919.000000 894.000000,904.000000 894.000000,889.000000 894.000000,879.000000 899.000000,869.000000 899.000000,884.000000 899.000000,899.000000 899.000000,914.000000 904.000000,919.000000 904.000000,904.000000 904.000000,889.000000 904.000000,874.000000 909.000000,869.000000 909.000000,884.000000 909.000000,899.000000 909.000000,914.000000 914.000000,914.000000 914.000000,904.000000 914.000000,889.000000 914.000000,874.000000 919.000000,874.000000 919.000000,889.000000 919.000000,899.000000 919.000000,914.000000 924.000000,914.000000 924.000000,899.000000 924.000000,884.000000 924.000000,874.000000 929.000000,874.000000 929.000000,889.000000 929.000000,904.000000 929.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="904.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">220</text>
+  <circle cx="992.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(3025.176000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-16.720000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 992.000000 894.000000" to="635.016000 992.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="967.000000,869.000000 967.000000,919.000000 1017.000000,919.000000 1017.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 992.000000 894.000000" to="465.048000 992.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="967.000000,869.000000 967.000000,894.000000 967.000000,919.000000 992.000000,919.000000 992.000000,894.000000 992.000000,869.000000 1017.000000,869.000000 1017.000000,894.000000 1017.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 992.000000 894.000000" to="7922.940000 992.000000 894.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="967.000000,869.000000 967.000000,879.000000 967.000000,894.000000 967.000000,909.000000 972.000000,919.000000 972.000000,909.000000 972.000000,894.000000 972.000000,879.000000 977.000000,869.000000 977.000000,884.000000 977.000000,894.000000 977.000000,909.000000 982.000000,919.000000 982.000000,904.000000 982.000000,889.000000 982.000000,879.000000 987.000000,869.000000 987.000000,884.000000 987.000000,899.000000 987.000000,914.000000 992.000000,919.000000 992.000000,904.000000 992.000000,889.000000 992.000000,874.000000 997.000000,869.000000 997.000000,884.000000 997.000000,899.000000 997.000000,914.000000 1002.000000,914.000000 1002.000000,904.000000 1002.000000,889.000000 1002.000000,874.000000 1007.000000,874.000000 1007.000000,889.000000 1007.000000,899.000000 1007.000000,914.000000 1012.000000,914.000000 1012.000000,899.000000 1012.000000,884.000000 1012.000000,874.000000 1017.000000,874.000000 1017.000000,889.000000 1017.000000,904.000000 1017.000000,919.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="992.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">66</text>
+  <circle cx="1080.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(3162.684000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-16.910000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 1080.000000 894.000000" to="635.016000 1080.000000 894.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="1055.000000,869.000000 1055.000000,919.000000 1105.000000,919.000000 1105.000000,869.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 1080.000000 894.000000" to="465.048000 1080.000000 894.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="1055.000000,869.000000 1055.000000,894.000000 1055.000000,919.000000 1080.000000,919.000000 1080.000000,894.000000 1080.000000,869.000000 1105.000000,869.000000 1105.000000,894.000000 1105.000000,919.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="1080.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">12</text>
+  <circle cx="1168.000000" cy="894.000000" r="27.000000" fill="#05050c" stroke="hsl(3300.192000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-17.100000s" repeatCount="indefinite"/>
+  </g>
+  <text x="1168.000000" y="866.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="68.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(1787.604000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-17.290000s" repeatCount="indefinite"/>
+  </g>
+  <text x="68.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+  <circle cx="156.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(1925.112000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-17.480000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 156.000000 956.000000" to="10365.624000 156.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="131.000000,931.000000 131.000000,943.500000 131.000000,960.166667 131.000000,976.833333 135.166667,972.666667 135.166667,956.000000 135.166667,939.333333 139.333333,935.166667 139.333333,951.833333 139.333333,968.500000 143.500000,981.000000 143.500000,968.500000 143.500000,951.833333 143.500000,935.166667 147.666667,939.333333 147.666667,956.000000 147.666667,972.666667 151.833333,976.833333 151.833333,960.166667 151.833333,943.500000 156.000000,931.000000 156.000000,947.666667 156.000000,960.166667 156.000000,976.833333 160.166667,972.666667 160.166667,956.000000 160.166667,939.333333 164.333333,935.166667 164.333333,951.833333 164.333333,968.500000 168.500000,981.000000 168.500000,964.333333 168.500000,947.666667 168.500000,935.166667 172.666667,939.333333 172.666667,956.000000 172.666667,972.666667 176.833333,976.833333 176.833333,960.166667 176.833333,943.500000 181.000000,931.000000 181.000000,947.666667 181.000000,964.333333 181.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="156.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">13</text>
+  <circle cx="244.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2062.620000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-17.670000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 244.000000 956.000000" to="635.016000 244.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="219.000000,931.000000 219.000000,981.000000 269.000000,981.000000 269.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 244.000000 956.000000" to="465.048000 244.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="219.000000,931.000000 219.000000,956.000000 219.000000,981.000000 244.000000,981.000000 244.000000,956.000000 244.000000,931.000000 269.000000,931.000000 269.000000,956.000000 269.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 244.000000 956.000000" to="10365.624000 244.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="219.000000,931.000000 219.000000,943.500000 219.000000,960.166667 219.000000,976.833333 223.166667,972.666667 223.166667,956.000000 223.166667,939.333333 227.333333,935.166667 227.333333,951.833333 227.333333,968.500000 231.500000,981.000000 231.500000,968.500000 231.500000,951.833333 231.500000,935.166667 235.666667,939.333333 235.666667,956.000000 235.666667,972.666667 239.833333,976.833333 239.833333,960.166667 239.833333,943.500000 244.000000,931.000000 244.000000,947.666667 244.000000,960.166667 244.000000,976.833333 248.166667,972.666667 248.166667,956.000000 248.166667,939.333333 252.333333,935.166667 252.333333,951.833333 252.333333,968.500000 256.500000,981.000000 256.500000,964.333333 256.500000,947.666667 256.500000,935.166667 260.666667,939.333333 260.666667,956.000000 260.666667,972.666667 264.833333,976.833333 264.833333,960.166667 264.833333,943.500000 269.000000,931.000000 269.000000,947.666667 269.000000,964.333333 269.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="244.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">78</text>
+  <circle cx="332.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2200.128000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-17.860000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 332.000000 956.000000" to="635.016000 332.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,931.000000 307.000000,981.000000 357.000000,981.000000 357.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 332.000000 956.000000" to="7922.940000 332.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,931.000000 307.000000,941.000000 307.000000,956.000000 307.000000,971.000000 312.000000,981.000000 312.000000,971.000000 312.000000,956.000000 312.000000,941.000000 317.000000,931.000000 317.000000,946.000000 317.000000,956.000000 317.000000,971.000000 322.000000,981.000000 322.000000,966.000000 322.000000,951.000000 322.000000,941.000000 327.000000,931.000000 327.000000,946.000000 327.000000,961.000000 327.000000,976.000000 332.000000,981.000000 332.000000,966.000000 332.000000,951.000000 332.000000,936.000000 337.000000,931.000000 337.000000,946.000000 337.000000,961.000000 337.000000,976.000000 342.000000,976.000000 342.000000,966.000000 342.000000,951.000000 342.000000,936.000000 347.000000,936.000000 347.000000,951.000000 347.000000,961.000000 347.000000,976.000000 352.000000,976.000000 352.000000,961.000000 352.000000,946.000000 352.000000,936.000000 357.000000,936.000000 357.000000,951.000000 357.000000,966.000000 357.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 332.000000 956.000000" to="10365.624000 332.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="307.000000,931.000000 307.000000,943.500000 307.000000,960.166667 307.000000,976.833333 311.166667,972.666667 311.166667,956.000000 311.166667,939.333333 315.333333,935.166667 315.333333,951.833333 315.333333,968.500000 319.500000,981.000000 319.500000,968.500000 319.500000,951.833333 319.500000,935.166667 323.666667,939.333333 323.666667,956.000000 323.666667,972.666667 327.833333,976.833333 327.833333,960.166667 327.833333,943.500000 332.000000,931.000000 332.000000,947.666667 332.000000,960.166667 332.000000,976.833333 336.166667,972.666667 336.166667,956.000000 336.166667,939.333333 340.333333,935.166667 340.333333,951.833333 340.333333,968.500000 344.500000,981.000000 344.500000,964.333333 344.500000,947.666667 344.500000,935.166667 348.666667,939.333333 348.666667,956.000000 348.666667,972.666667 352.833333,976.833333 352.833333,960.166667 352.833333,943.500000 357.000000,931.000000 357.000000,947.666667 357.000000,964.333333 357.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="332.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">286</text>
+  <circle cx="420.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2337.636000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-18.050000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 420.000000 956.000000" to="2422.620000 420.000000 956.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,931.000000 395.000000,943.500000 395.000000,956.000000 395.000000,968.500000 395.000000,981.000000 407.500000,981.000000 407.500000,968.500000 407.500000,956.000000 407.500000,943.500000 407.500000,931.000000 420.000000,931.000000 420.000000,943.500000 420.000000,956.000000 420.000000,968.500000 420.000000,981.000000 432.500000,981.000000 432.500000,968.500000 432.500000,956.000000 432.500000,943.500000 432.500000,931.000000 445.000000,931.000000 445.000000,943.500000 445.000000,956.000000 445.000000,968.500000 445.000000,981.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 420.000000 956.000000" to="7922.940000 420.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,931.000000 395.000000,941.000000 395.000000,956.000000 395.000000,971.000000 400.000000,981.000000 400.000000,971.000000 400.000000,956.000000 400.000000,941.000000 405.000000,931.000000 405.000000,946.000000 405.000000,956.000000 405.000000,971.000000 410.000000,981.000000 410.000000,966.000000 410.000000,951.000000 410.000000,941.000000 415.000000,931.000000 415.000000,946.000000 415.000000,961.000000 415.000000,976.000000 420.000000,981.000000 420.000000,966.000000 420.000000,951.000000 420.000000,936.000000 425.000000,931.000000 425.000000,946.000000 425.000000,961.000000 425.000000,976.000000 430.000000,976.000000 430.000000,966.000000 430.000000,951.000000 430.000000,936.000000 435.000000,936.000000 435.000000,951.000000 435.000000,961.000000 435.000000,976.000000 440.000000,976.000000 440.000000,961.000000 440.000000,946.000000 440.000000,936.000000 445.000000,936.000000 445.000000,951.000000 445.000000,966.000000 445.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 420.000000 956.000000" to="10365.624000 420.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="395.000000,931.000000 395.000000,943.500000 395.000000,960.166667 395.000000,976.833333 399.166667,972.666667 399.166667,956.000000 399.166667,939.333333 403.333333,935.166667 403.333333,951.833333 403.333333,968.500000 407.500000,981.000000 407.500000,968.500000 407.500000,951.833333 407.500000,935.166667 411.666667,939.333333 411.666667,956.000000 411.666667,972.666667 415.833333,976.833333 415.833333,960.166667 415.833333,943.500000 420.000000,931.000000 420.000000,947.666667 420.000000,960.166667 420.000000,976.833333 424.166667,972.666667 424.166667,956.000000 424.166667,939.333333 428.333333,935.166667 428.333333,951.833333 428.333333,968.500000 432.500000,981.000000 432.500000,964.333333 432.500000,947.666667 432.500000,935.166667 436.666667,939.333333 436.666667,956.000000 436.666667,972.666667 440.833333,976.833333 440.833333,960.166667 440.833333,943.500000 445.000000,931.000000 445.000000,947.666667 445.000000,964.333333 445.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="420.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">715</text>
+  <circle cx="508.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2475.144000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-18.240000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 508.000000 956.000000" to="465.048000 508.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,931.000000 483.000000,956.000000 483.000000,981.000000 508.000000,981.000000 508.000000,956.000000 508.000000,931.000000 533.000000,931.000000 533.000000,956.000000 533.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 508.000000 956.000000" to="7922.940000 508.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,931.000000 483.000000,941.000000 483.000000,956.000000 483.000000,971.000000 488.000000,981.000000 488.000000,971.000000 488.000000,956.000000 488.000000,941.000000 493.000000,931.000000 493.000000,946.000000 493.000000,956.000000 493.000000,971.000000 498.000000,981.000000 498.000000,966.000000 498.000000,951.000000 498.000000,941.000000 503.000000,931.000000 503.000000,946.000000 503.000000,961.000000 503.000000,976.000000 508.000000,981.000000 508.000000,966.000000 508.000000,951.000000 508.000000,936.000000 513.000000,931.000000 513.000000,946.000000 513.000000,961.000000 513.000000,976.000000 518.000000,976.000000 518.000000,966.000000 518.000000,951.000000 518.000000,936.000000 523.000000,936.000000 523.000000,951.000000 523.000000,961.000000 523.000000,976.000000 528.000000,976.000000 528.000000,961.000000 528.000000,946.000000 528.000000,936.000000 533.000000,936.000000 533.000000,951.000000 533.000000,966.000000 533.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 508.000000 956.000000" to="10365.624000 508.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="483.000000,931.000000 483.000000,943.500000 483.000000,960.166667 483.000000,976.833333 487.166667,972.666667 487.166667,956.000000 487.166667,939.333333 491.333333,935.166667 491.333333,951.833333 491.333333,968.500000 495.500000,981.000000 495.500000,968.500000 495.500000,951.833333 495.500000,935.166667 499.666667,939.333333 499.666667,956.000000 499.666667,972.666667 503.833333,976.833333 503.833333,960.166667 503.833333,943.500000 508.000000,931.000000 508.000000,947.666667 508.000000,960.166667 508.000000,976.833333 512.166667,972.666667 512.166667,956.000000 512.166667,939.333333 516.333333,935.166667 516.333333,951.833333 516.333333,968.500000 520.500000,981.000000 520.500000,964.333333 520.500000,947.666667 520.500000,935.166667 524.666667,939.333333 524.666667,956.000000 524.666667,972.666667 528.833333,976.833333 528.833333,960.166667 528.833333,943.500000 533.000000,931.000000 533.000000,947.666667 533.000000,964.333333 533.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="508.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1287</text>
+  <circle cx="596.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2612.652000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-18.430000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 596.000000 956.000000" to="635.016000 596.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,931.000000 571.000000,981.000000 621.000000,981.000000 621.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 596.000000 956.000000" to="465.048000 596.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,931.000000 571.000000,956.000000 571.000000,981.000000 596.000000,981.000000 596.000000,956.000000 596.000000,931.000000 621.000000,931.000000 621.000000,956.000000 621.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 596.000000 956.000000" to="7922.940000 596.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,931.000000 571.000000,941.000000 571.000000,956.000000 571.000000,971.000000 576.000000,981.000000 576.000000,971.000000 576.000000,956.000000 576.000000,941.000000 581.000000,931.000000 581.000000,946.000000 581.000000,956.000000 581.000000,971.000000 586.000000,981.000000 586.000000,966.000000 586.000000,951.000000 586.000000,941.000000 591.000000,931.000000 591.000000,946.000000 591.000000,961.000000 591.000000,976.000000 596.000000,981.000000 596.000000,966.000000 596.000000,951.000000 596.000000,936.000000 601.000000,931.000000 601.000000,946.000000 601.000000,961.000000 601.000000,976.000000 606.000000,976.000000 606.000000,966.000000 606.000000,951.000000 606.000000,936.000000 611.000000,936.000000 611.000000,951.000000 611.000000,961.000000 611.000000,976.000000 616.000000,976.000000 616.000000,961.000000 616.000000,946.000000 616.000000,936.000000 621.000000,936.000000 621.000000,951.000000 621.000000,966.000000 621.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 596.000000 956.000000" to="10365.624000 596.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="571.000000,931.000000 571.000000,943.500000 571.000000,960.166667 571.000000,976.833333 575.166667,972.666667 575.166667,956.000000 575.166667,939.333333 579.333333,935.166667 579.333333,951.833333 579.333333,968.500000 583.500000,981.000000 583.500000,968.500000 583.500000,951.833333 583.500000,935.166667 587.666667,939.333333 587.666667,956.000000 587.666667,972.666667 591.833333,976.833333 591.833333,960.166667 591.833333,943.500000 596.000000,931.000000 596.000000,947.666667 596.000000,960.166667 596.000000,976.833333 600.166667,972.666667 600.166667,956.000000 600.166667,939.333333 604.333333,935.166667 604.333333,951.833333 604.333333,968.500000 608.500000,981.000000 608.500000,964.333333 608.500000,947.666667 608.500000,935.166667 612.666667,939.333333 612.666667,956.000000 612.666667,972.666667 616.833333,976.833333 616.833333,960.166667 616.833333,943.500000 621.000000,931.000000 621.000000,947.666667 621.000000,964.333333 621.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="596.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1716</text>
+  <circle cx="684.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2750.160000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-18.620000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 684.000000 956.000000" to="635.016000 684.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,931.000000 659.000000,981.000000 709.000000,981.000000 709.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 684.000000 956.000000" to="465.048000 684.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,931.000000 659.000000,956.000000 659.000000,981.000000 684.000000,981.000000 684.000000,956.000000 684.000000,931.000000 709.000000,931.000000 709.000000,956.000000 709.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 684.000000 956.000000" to="7922.940000 684.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,931.000000 659.000000,941.000000 659.000000,956.000000 659.000000,971.000000 664.000000,981.000000 664.000000,971.000000 664.000000,956.000000 664.000000,941.000000 669.000000,931.000000 669.000000,946.000000 669.000000,956.000000 669.000000,971.000000 674.000000,981.000000 674.000000,966.000000 674.000000,951.000000 674.000000,941.000000 679.000000,931.000000 679.000000,946.000000 679.000000,961.000000 679.000000,976.000000 684.000000,981.000000 684.000000,966.000000 684.000000,951.000000 684.000000,936.000000 689.000000,931.000000 689.000000,946.000000 689.000000,961.000000 689.000000,976.000000 694.000000,976.000000 694.000000,966.000000 694.000000,951.000000 694.000000,936.000000 699.000000,936.000000 699.000000,951.000000 699.000000,961.000000 699.000000,976.000000 704.000000,976.000000 704.000000,961.000000 704.000000,946.000000 704.000000,936.000000 709.000000,936.000000 709.000000,951.000000 709.000000,966.000000 709.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 684.000000 956.000000" to="10365.624000 684.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="659.000000,931.000000 659.000000,943.500000 659.000000,960.166667 659.000000,976.833333 663.166667,972.666667 663.166667,956.000000 663.166667,939.333333 667.333333,935.166667 667.333333,951.833333 667.333333,968.500000 671.500000,981.000000 671.500000,968.500000 671.500000,951.833333 671.500000,935.166667 675.666667,939.333333 675.666667,956.000000 675.666667,972.666667 679.833333,976.833333 679.833333,960.166667 679.833333,943.500000 684.000000,931.000000 684.000000,947.666667 684.000000,960.166667 684.000000,976.833333 688.166667,972.666667 688.166667,956.000000 688.166667,939.333333 692.333333,935.166667 692.333333,951.833333 692.333333,968.500000 696.500000,981.000000 696.500000,964.333333 696.500000,947.666667 696.500000,935.166667 700.666667,939.333333 700.666667,956.000000 700.666667,972.666667 704.833333,976.833333 704.833333,960.166667 704.833333,943.500000 709.000000,931.000000 709.000000,947.666667 709.000000,964.333333 709.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="684.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1716</text>
+  <circle cx="772.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(2887.668000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-18.810000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 772.000000 956.000000" to="465.048000 772.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,931.000000 747.000000,956.000000 747.000000,981.000000 772.000000,981.000000 772.000000,956.000000 772.000000,931.000000 797.000000,931.000000 797.000000,956.000000 797.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 772.000000 956.000000" to="7922.940000 772.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,931.000000 747.000000,941.000000 747.000000,956.000000 747.000000,971.000000 752.000000,981.000000 752.000000,971.000000 752.000000,956.000000 752.000000,941.000000 757.000000,931.000000 757.000000,946.000000 757.000000,956.000000 757.000000,971.000000 762.000000,981.000000 762.000000,966.000000 762.000000,951.000000 762.000000,941.000000 767.000000,931.000000 767.000000,946.000000 767.000000,961.000000 767.000000,976.000000 772.000000,981.000000 772.000000,966.000000 772.000000,951.000000 772.000000,936.000000 777.000000,931.000000 777.000000,946.000000 777.000000,961.000000 777.000000,976.000000 782.000000,976.000000 782.000000,966.000000 782.000000,951.000000 782.000000,936.000000 787.000000,936.000000 787.000000,951.000000 787.000000,961.000000 787.000000,976.000000 792.000000,976.000000 792.000000,961.000000 792.000000,946.000000 792.000000,936.000000 797.000000,936.000000 797.000000,951.000000 797.000000,966.000000 797.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 772.000000 956.000000" to="10365.624000 772.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="747.000000,931.000000 747.000000,943.500000 747.000000,960.166667 747.000000,976.833333 751.166667,972.666667 751.166667,956.000000 751.166667,939.333333 755.333333,935.166667 755.333333,951.833333 755.333333,968.500000 759.500000,981.000000 759.500000,968.500000 759.500000,951.833333 759.500000,935.166667 763.666667,939.333333 763.666667,956.000000 763.666667,972.666667 767.833333,976.833333 767.833333,960.166667 767.833333,943.500000 772.000000,931.000000 772.000000,947.666667 772.000000,960.166667 772.000000,976.833333 776.166667,972.666667 776.166667,956.000000 776.166667,939.333333 780.333333,935.166667 780.333333,951.833333 780.333333,968.500000 784.500000,981.000000 784.500000,964.333333 784.500000,947.666667 784.500000,935.166667 788.666667,939.333333 788.666667,956.000000 788.666667,972.666667 792.833333,976.833333 792.833333,960.166667 792.833333,943.500000 797.000000,931.000000 797.000000,947.666667 797.000000,964.333333 797.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="772.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1287</text>
+  <circle cx="860.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(3025.176000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-19.000000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="2062.620000 860.000000 956.000000" to="2422.620000 860.000000 956.000000" dur="21.000000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,931.000000 835.000000,943.500000 835.000000,956.000000 835.000000,968.500000 835.000000,981.000000 847.500000,981.000000 847.500000,968.500000 847.500000,956.000000 847.500000,943.500000 847.500000,931.000000 860.000000,931.000000 860.000000,943.500000 860.000000,956.000000 860.000000,968.500000 860.000000,981.000000 872.500000,981.000000 872.500000,968.500000 872.500000,956.000000 872.500000,943.500000 872.500000,931.000000 885.000000,931.000000 885.000000,943.500000 885.000000,956.000000 885.000000,968.500000 885.000000,981.000000" fill="none" stroke="#ffd23e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 860.000000 956.000000" to="7922.940000 860.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,931.000000 835.000000,941.000000 835.000000,956.000000 835.000000,971.000000 840.000000,981.000000 840.000000,971.000000 840.000000,956.000000 840.000000,941.000000 845.000000,931.000000 845.000000,946.000000 845.000000,956.000000 845.000000,971.000000 850.000000,981.000000 850.000000,966.000000 850.000000,951.000000 850.000000,941.000000 855.000000,931.000000 855.000000,946.000000 855.000000,961.000000 855.000000,976.000000 860.000000,981.000000 860.000000,966.000000 860.000000,951.000000 860.000000,936.000000 865.000000,931.000000 865.000000,946.000000 865.000000,961.000000 865.000000,976.000000 870.000000,976.000000 870.000000,966.000000 870.000000,951.000000 870.000000,936.000000 875.000000,936.000000 875.000000,951.000000 875.000000,961.000000 875.000000,976.000000 880.000000,976.000000 880.000000,961.000000 880.000000,946.000000 880.000000,936.000000 885.000000,936.000000 885.000000,951.000000 885.000000,966.000000 885.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 860.000000 956.000000" to="10365.624000 860.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="835.000000,931.000000 835.000000,943.500000 835.000000,960.166667 835.000000,976.833333 839.166667,972.666667 839.166667,956.000000 839.166667,939.333333 843.333333,935.166667 843.333333,951.833333 843.333333,968.500000 847.500000,981.000000 847.500000,968.500000 847.500000,951.833333 847.500000,935.166667 851.666667,939.333333 851.666667,956.000000 851.666667,972.666667 855.833333,976.833333 855.833333,960.166667 855.833333,943.500000 860.000000,931.000000 860.000000,947.666667 860.000000,960.166667 860.000000,976.833333 864.166667,972.666667 864.166667,956.000000 864.166667,939.333333 868.333333,935.166667 868.333333,951.833333 868.333333,968.500000 872.500000,981.000000 872.500000,964.333333 872.500000,947.666667 872.500000,935.166667 876.666667,939.333333 876.666667,956.000000 876.666667,972.666667 880.833333,976.833333 880.833333,960.166667 880.833333,943.500000 885.000000,931.000000 885.000000,947.666667 885.000000,964.333333 885.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="860.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">715</text>
+  <circle cx="948.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(3162.684000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-19.190000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 948.000000 956.000000" to="635.016000 948.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,931.000000 923.000000,981.000000 973.000000,981.000000 973.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="7562.940000 948.000000 956.000000" to="7922.940000 948.000000 956.000000" dur="28.000000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,931.000000 923.000000,941.000000 923.000000,956.000000 923.000000,971.000000 928.000000,981.000000 928.000000,971.000000 928.000000,956.000000 928.000000,941.000000 933.000000,931.000000 933.000000,946.000000 933.000000,956.000000 933.000000,971.000000 938.000000,981.000000 938.000000,966.000000 938.000000,951.000000 938.000000,941.000000 943.000000,931.000000 943.000000,946.000000 943.000000,961.000000 943.000000,976.000000 948.000000,981.000000 948.000000,966.000000 948.000000,951.000000 948.000000,936.000000 953.000000,931.000000 953.000000,946.000000 953.000000,961.000000 953.000000,976.000000 958.000000,976.000000 958.000000,966.000000 958.000000,951.000000 958.000000,936.000000 963.000000,936.000000 963.000000,951.000000 963.000000,961.000000 963.000000,976.000000 968.000000,976.000000 968.000000,961.000000 968.000000,946.000000 968.000000,936.000000 973.000000,936.000000 973.000000,951.000000 973.000000,966.000000 973.000000,981.000000" fill="none" stroke="#ff8a3e" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 948.000000 956.000000" to="10365.624000 948.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="923.000000,931.000000 923.000000,943.500000 923.000000,960.166667 923.000000,976.833333 927.166667,972.666667 927.166667,956.000000 927.166667,939.333333 931.333333,935.166667 931.333333,951.833333 931.333333,968.500000 935.500000,981.000000 935.500000,968.500000 935.500000,951.833333 935.500000,935.166667 939.666667,939.333333 939.666667,956.000000 939.666667,972.666667 943.833333,976.833333 943.833333,960.166667 943.833333,943.500000 948.000000,931.000000 948.000000,947.666667 948.000000,960.166667 948.000000,976.833333 952.166667,972.666667 952.166667,956.000000 952.166667,939.333333 956.333333,935.166667 956.333333,951.833333 956.333333,968.500000 960.500000,981.000000 960.500000,964.333333 960.500000,947.666667 960.500000,935.166667 964.666667,939.333333 964.666667,956.000000 964.666667,972.666667 968.833333,976.833333 968.833333,960.166667 968.833333,943.500000 973.000000,931.000000 973.000000,947.666667 973.000000,964.333333 973.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="948.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">286</text>
+  <circle cx="1036.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(3300.192000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-19.380000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="275.016000 1036.000000 956.000000" to="635.016000 1036.000000 956.000000" dur="14.000000s" repeatCount="indefinite"/>
+      <polyline points="1011.000000,931.000000 1011.000000,981.000000 1061.000000,981.000000 1061.000000,931.000000" fill="none" stroke="#33e6ff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="825.048000 1036.000000 956.000000" to="465.048000 1036.000000 956.000000" dur="17.500000s" repeatCount="indefinite"/>
+      <polyline points="1011.000000,931.000000 1011.000000,956.000000 1011.000000,981.000000 1036.000000,981.000000 1036.000000,956.000000 1036.000000,931.000000 1061.000000,931.000000 1061.000000,956.000000 1061.000000,981.000000" fill="none" stroke="#ff3ea5" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 1036.000000 956.000000" to="10365.624000 1036.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="1011.000000,931.000000 1011.000000,943.500000 1011.000000,960.166667 1011.000000,976.833333 1015.166667,972.666667 1015.166667,956.000000 1015.166667,939.333333 1019.333333,935.166667 1019.333333,951.833333 1019.333333,968.500000 1023.500000,981.000000 1023.500000,968.500000 1023.500000,951.833333 1023.500000,935.166667 1027.666667,939.333333 1027.666667,956.000000 1027.666667,972.666667 1031.833333,976.833333 1031.833333,960.166667 1031.833333,943.500000 1036.000000,931.000000 1036.000000,947.666667 1036.000000,960.166667 1036.000000,976.833333 1040.166667,972.666667 1040.166667,956.000000 1040.166667,939.333333 1044.333333,935.166667 1044.333333,951.833333 1044.333333,968.500000 1048.500000,981.000000 1048.500000,964.333333 1048.500000,947.666667 1048.500000,935.166667 1052.666667,939.333333 1052.666667,956.000000 1052.666667,972.666667 1056.833333,976.833333 1056.833333,960.166667 1056.833333,943.500000 1061.000000,931.000000 1061.000000,947.666667 1061.000000,964.333333 1061.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="1036.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">78</text>
+  <circle cx="1124.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(3437.700000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-19.570000s" repeatCount="indefinite"/>
+    <g style="mix-blend-mode:screen">
+      <animateTransform attributeName="transform" type="rotate" from="10725.624000 1124.000000 956.000000" to="10365.624000 1124.000000 956.000000" dur="31.500000s" repeatCount="indefinite"/>
+      <polyline points="1099.000000,931.000000 1099.000000,943.500000 1099.000000,960.166667 1099.000000,976.833333 1103.166667,972.666667 1103.166667,956.000000 1103.166667,939.333333 1107.333333,935.166667 1107.333333,951.833333 1107.333333,968.500000 1111.500000,981.000000 1111.500000,968.500000 1111.500000,951.833333 1111.500000,935.166667 1115.666667,939.333333 1115.666667,956.000000 1115.666667,972.666667 1119.833333,976.833333 1119.833333,960.166667 1119.833333,943.500000 1124.000000,931.000000 1124.000000,947.666667 1124.000000,960.166667 1124.000000,976.833333 1128.166667,972.666667 1128.166667,956.000000 1128.166667,939.333333 1132.333333,935.166667 1132.333333,951.833333 1132.333333,968.500000 1136.500000,981.000000 1136.500000,964.333333 1136.500000,947.666667 1136.500000,935.166667 1140.666667,939.333333 1140.666667,956.000000 1140.666667,972.666667 1144.833333,976.833333 1144.833333,960.166667 1144.833333,943.500000 1149.000000,931.000000 1149.000000,947.666667 1149.000000,964.333333 1149.000000,981.000000" fill="none" stroke="#b06cff" stroke-width="0.600000" stroke-linejoin="round" stroke-linecap="round" opacity="0.550000"/>
+    </g>
+  </g>
+  <text x="1124.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">13</text>
+  <circle cx="1212.000000" cy="956.000000" r="27.000000" fill="#05050c" stroke="hsl(3575.208000 70% 55%)" stroke-width="0.9"/>
+  <g>
+    <animate attributeName="opacity" values="1;0.8;0.16;0.8;1" keyTimes="0;0.25;0.5;0.75;1" dur="12s" begin="-19.760000s" repeatCount="indefinite"/>
+  </g>
+  <text x="1212.000000" y="928.000000" fill="#cfd4ff" font-family="monospace" font-size="7" text-anchor="middle">1</text>
+</svg>


### PR DESCRIPTION
Aristotle finished successfully


Here's what it did:
I created hilbert_adic_pascal_lenses.svg by fusing the two figures you named: the Pascal-triangle layout of hilbert_adic_pascal_sphere_trace_spin.svg with the conflation-lens rendering of hilbert_adic_lenses.svg.What it shows: Pascal's triangle (rows 0–13, 105 entries) where each binomial entry C(r,c) is drawn as its own conflation lens instead of a sphere trace. Each lens overlays that entry's prime-power towers p^vₚ(C(r,c)) — the p-adic valuations of the binomial across the fifteen Ogg/supersingular primes — as base-p space-filling curves (base 2 Hilbert, the rest generalised Peano), reusing the exact lens machinery from the lenses figure: curves are screen-blended, each spun at its own rate (interference), and pulsed in opacity to cohere ⇄ decohere, with the pulse phased across the triangle so the whole array ripples. Discs are framed in the diagonal's golden-angle colour and labelled with the value; the header keeps the same prime→colour legend.New files: RequestProject/AdicPascalLenses.lean — the generator plus two proved (sorry-free) backing theorems: entryExps_symm (mirror entries C(r,c)/C(r,r−c) share the same signature) and entry_ogg_dvd (for every drawn entry the product ∏ₚ p^vₚ actually divides C(r,c), so the exponents really are p-adic valuations — Kummer's carry count). RequestProject/GenAdicPascalLenses.lean — regenerate with lake env lean --run RequestProject/GenAdicPascalLenses.lean. Verification: both modules build; the SVG parses as well-formed XML (105 lens discs = all Pascal entries, 183 tower polylines); both theorems use only allowed axioms and no sorry remains. All work is committed and pushed