### PR TITLE
Add Type 8 for memes and update keywords

### DIFF
--- a/0xDA51PrefixClassification.md
+++ b/0xDA51PrefixClassification.md
@@ -1,97 +1,87 @@
---- 20260318_064546_0xda51_prefix_classification ---
-Title: 0xDA51 Prefix Classification
-Keywords: 
+Title: 0xDA51 Prefix Classification (updated to include the memes)
+Keywords: dasl, monster, memes, biomes, fractran, hilbert, moonshine
 CID: bafkd67f91d942829760302a40f474d9d5f3
 Witness: d67f91d942829760302a40f474d9d5f3b8d8897c393c125d680f63278c737881
 IPFS: QmRSD3VunBq4KiWhkFfs3hyaoBYRdfg82qLBrFJ7mqeEJR
 DASL: 0xda513010904d9428
-Reply-To: 
-
+Reply-To:
+> **Update note (2026-07-11).** This revision extends the original 0xDA51
+> taxonomy to cover this project's **memes** — the FRACTRAN Hilbert-life *biomes*
+> of `RequestProject.Biome`, each namable by a compact `meme:` URL
+> (`RequestProject.MemeUrl`) and enumerable as IPLD DAG-CBOR blocks
+> (`docs/rfc-0001-meme-ipld-dagcbor.md`). Nothing in the original layout changes;
+> the memes are added as a new **Type 8** address and cross-referenced from the
+> FRACTRAN, eigenspace, and address-space sections. The mapping between a `meme:`
+> URL and its 0xDA51 address is *machine-checked* in `RequestProject.Da51`
+> (round-trip theorems `getOrder_encodeMeme`, …, `toMeme_ofMeme`). Text that was
+> mojibake in the source (`âœ“`, `Ã—`, `âˆ’`, `Ï‡`, …) has been rendered as the
+> intended Unicode (`✓`, `×`, `−`, `χ`, …).
 # 0xDA51 Prefix Classification
-
-**Complete taxonomy of Monster Walk Addressing terms**
-
+**Complete taxonomy of Monster Walk Addressing terms** — now including the memes.
 ## The Prefix: 0xDA51
-
 **Etymology**: DASL (Data-Addressed Structures & Links)
 - **DA** = Data-Addressed
 - **51** = Hexadecimal for 81 decimal
 - **Binary**: `1101 1010 0101 0001`
-
 ## Address Format
-
 ```
 [prefix:16][type:4][data:44]
-
 Total: 64 bits
 ```
-
 ### Bit Layout
 ```
 Bits 63-48: 0xDA51 (prefix, constant)
-Bits 47-44: Type field (0-5)
+Bits 47-44: Type field (0-8)
 Bits 43-0:  Type-specific data
 ```
-
 ## Type Field (4 bits = 16 possible types)
-
+The type field now ranges 0–8. Types 0–7 are unchanged from the original spec;
+**Type 8 (Meme)** is new and carries the project's biomes.
 ### Type 0: Monster Walk Block
 **Purpose**: 10-block Monster Walk with Bott periodicity
-
 **Data layout**:
 ```
 [group:4][position:8][sequence:16][factors:4][pad:12]
 ```
-
 **Terms**:
 - **group**: 0-9 (10 Monster Walk blocks)
 - **position**: Position in Monster order decimal expansion
 - **sequence**: 4-digit sequence from Monster order
 - **factors**: Number of prime factors removed (Bott periodicity)
-
 **Example**: `0xDA510001F9080000`
 - prefix: 0xDA51
 - type: 0 (Monster Walk)
 - group: 0
 - position: 0
 - sequence: 8080
-- factors: 8 (Bott periodic âœ“)
-
+- factors: 8 (Bott periodic ✓)
 ## Monster Group RPC Compression
-
 **File**: `RPC_MONSTER_COMPRESSED.json`
-
 **Compression Results**:
 - Original: 1,258 bytes (50 RPC URLs)
 - Monster CBOR: 1,150 bytes (91.4%)
 - **Symmetry-exploited: 838 bytes (66.6%)**
-
 **Symmetries Used**:
 - **71-fold rotation**: 36 equivalence classes (1.4 avg per class)
 - **59-fold reflection**: 34 equivalence classes (1.5 avg per class)
 - **47-fold duality**: 33 equivalence classes (1.5 avg per class)
 - **8-fold Bott periodicity**: 8 classes (6.2 avg per class)
 - **Eigenspace partition**: Earth(7D)/Spoke(5D)/Hub(1D)/Clock(2D)
-
 **Eigenspace-aware encoding** (Exp11):
 ```
-URL â†’ SHA256 â†’ eigenspace_project(hash)
-    â†’ (earth_7, spoke_5, hub_1, clock_2)
-    â†’ DA51 address with eigenspace tag
-    â†’ CBOR map {a: address, e: eigenspace, u: suffix}
+URL → SHA256 → eigenspace_project(hash)
+    → (earth_7, spoke_5, hub_1, clock_2)
+    → DA51 address with eigenspace tag
+    → CBOR map {a: address, e: eigenspace, u: suffix}
 ```
-
-The câ‚ weighting: Earth primes carry 99.9996% of representation energy,
+The c₁ weighting: Earth primes carry 99.9996% of representation energy,
 so Earth-tagged addresses get priority routing.
-
 ### Type 1: AST Node
 **Purpose**: Abstract Syntax Tree nodes with triple view
-
 **Data layout**:
 ```
 [selector:3][bott:3][tenfold:11][hecke:7][hash:20]
 ```
-
 **Terms**:
 - **selector**: Which views are active (bit flags)
   - Bit 0: Bott view active
@@ -102,11 +92,11 @@ so Earth-tagged addresses get priority routing.
   - 0: R (reals)
   - 1: C (complex)
   - 2: H (quaternions)
-  - 3: HâŠ•H (split quaternions)
-  - 4: H(2) (2Ã—2 quaternion matrices)
-  - 5: C(4) (4Ã—4 complex matrices)
-  - 6: R(8) (8Ã—8 real matrices)
-  - 7: R(8)âŠ•R(8) (split 8Ã—8 reals)
+  - 3: H⊕H (split quaternions)
+  - 4: H(2) (2×2 quaternion matrices)
+  - 5: C(4) (4×4 complex matrices)
+  - 6: R(8) (8×8 real matrices)
+  - 7: R(8)⊕R(8) (split 8×8 reals)
 - **tenfold**: Altland-Zirnbauer symmetry class (0-10)
   - 0: Cl(10,0) - A (Unitary)
   - 1: Cl(9,1) - AIII (Chiral unitary)
@@ -126,7 +116,6 @@ so Earth-tagged addresses get priority routing.
   - ...
   - 14: T_71
 - **hash**: SHA256(node_data)[3:6] (20 bits)
-
 **Example**: `0xDA51E0000011C000`
 - prefix: 0xDA51
 - type: 1 (AST Node)
@@ -135,43 +124,35 @@ so Earth-tagged addresses get priority routing.
 - tenfold: 0 (Cl(10,0), A)
 - hecke: 14 (T_71)
 - hash: 0x00000
-
 ### Type 2: Monster Protocol
 **Purpose**: Protocol negotiation and capability exchange
-
 **Data layout**:
 ```
 [protocol_id:8][version:8][capabilities:28]
 ```
-
 **Terms**:
 - **protocol_id**: 0-255 (256 protocols)
   - Maps to 295 Monster conjugacy classes (compressed)
 - **version**: Protocol version (0-255)
 - **capabilities**: Bit flags for protocol features
-
 **Example**: `0xDA52010000000001`
 - prefix: 0xDA51
 - type: 2 (Protocol)
 - protocol_id: 1
 - version: 0
 - capabilities: 0x0000001
-
 ### Type 3: Nested CID
 **Purpose**: Content-addressed data with Monster structure
-
 **Data layout**:
 ```
 [shard:8][hecke:8][bott:8][hash:20]
 ```
-
 **Terms**:
 - **shard**: 0-70 (71 supersingular primes, OEIS A002267)
   - 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 41, 47, 59, 71
 - **hecke**: 0-58 (59 Hecke operators for error correction)
 - **bott**: 0-46 (47 Bott periodicity phases)
 - **hash**: SHA256(content)[3:6] (20 bits)
-
 **Example**: `0xDA513AE3392F2B7F`
 - prefix: 0xDA51
 - type: 3 (Nested CID)
@@ -179,15 +160,12 @@ so Earth-tagged addresses get priority routing.
 - hecke: 35
 - bott: 41
 - hash: 0x92F2B7F
-
 ### Type 4: Harmonic Path
 **Purpose**: Routing between 10-fold and 8-fold ways
-
 **Data layout**:
 ```
 [source:4][dest:4][harmonic:8][transition:28]
 ```
-
 **Terms**:
 - **source**: Source symmetry class (0-10 for 10-fold, 0-7 for 8-fold)
 - **dest**: Destination symmetry class
@@ -196,7 +174,6 @@ so Earth-tagged addresses get priority routing.
   - LCM(10,8) = 40
   - 80 prime transitions
 - **transition**: Path through Monster symmetries
-
 **Example**: `0xDA5140A0280...`
 - prefix: 0xDA51
 - type: 4 (Harmonic Path)
@@ -204,24 +181,20 @@ so Earth-tagged addresses get priority routing.
 - dest: 10 (8-fold R)
 - harmonic: 40 (LCM)
 - transition: ...
-
 ### Type 5: Shard ID
 **Purpose**: Distributed storage sharding
-
 **Data layout**:
 ```
 [prime_idx:4][replica:4][zone:8][node:28]
 ```
-
 **Terms**:
 - **prime_idx**: Index into 15 Monster primes (0-14)
   - 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 41, 47, 59, 71
-- **replica**: Replica number (0-15, typically 3Ã— replication)
+- **replica**: Replica number (0-15, typically 3× replication)
 - **zone**: Geographic/logical zone (0-255)
   - Zone 42: Compilation + Payment
   - Zone 71: Ingestion
 - **node**: Node ID within zone (0-268M)
-
 **Example**: `0xDA515E2A00000001`
 - prefix: 0xDA51
 - type: 5 (Shard)
@@ -229,54 +202,46 @@ so Earth-tagged addresses get priority routing.
 - replica: 2
 - zone: 42
 - node: 1
-
 ### Type 6: Eigenspace Address
 **Purpose**: Cl(15,0,0) eigenspace-aware content addressing
-
 **Data layout**:
 ```
 [eigenspace:2][prime_idx:4][mckay:6][hub_proj:4][hash:28]
 ```
-
 **Terms**:
 - **eigenspace**: Which eigenspace of O (2 bits)
-  - 0: Earth (eigenvalue âˆ’1, primes {2,3,5,7,11,13,47})
-  - 1: Spoke (eigenvalue âˆ’1, mixed from {17,29,31,41,59,71})
-  - 2: Hub (eigenvalue +1, direction (eâ‚â‚‰+eâ‚‚â‚ƒ)/âˆš2)
-  - 3: Clock (eigenvalue e^{Â±iÏ€/3}, 60Â° rotation plane)
+  - 0: Earth (eigenvalue −1, primes {2,3,5,7,11,13,47})
+  - 1: Spoke (eigenvalue −1, mixed from {17,29,31,41,59,71})
+  - 2: Hub (eigenvalue +1, direction (e₁₉+e₂₃)/√2)
+  - 3: Clock (eigenvalue e^{±iπ/3}, 60° rotation plane)
 - **prime_idx**: Index into 15 SSP (0-14)
-- **mckay**: McKay-Thompson câ‚ value mod 64 (6 bits)
-  - Encodes Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(pa) mod 64
-  - For p â‰¥ 13: equals 196883 mod p (mod 64)
+- **mckay**: McKay-Thompson c₁ value mod 64 (6 bits)
+  - Encodes χ₁₉₆₈₈₃(pa) mod 64
+  - For p ≥ 13: equals 196883 mod p (mod 64)
 - **hub_proj**: Hub axis projection quantized (4 bits)
   - 0-15 mapping to projection strength
 - **hash**: Content hash (28 bits)
-
 **Example**: `0xDA5160750A000000`
 - prefix: 0xDA51
 - type: 6 (Eigenspace)
 - eigenspace: 2 (Hub)
 - prime_idx: 7 (prime 19)
-- mckay: 5 (Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(19a) = 5)
-- hub_proj: 15 (maximum â€” 19 is the hub)
+- mckay: 5 (χ₁₉₆₈₈₃(19a) = 5)
+- hub_proj: 15 (maximum — 19 is the hub)
 - hash: 0x0000000
-
 **Routing rule**: Earth-tagged addresses (eigenspace=0) get priority
 (99.9996% of moonshine energy). Hub addresses (eigenspace=2) are
 skeleton-critical. Clock addresses (eigenspace=3) carry the 196883
 trivector structure.
-
 ### Type 7: Hauptmodul Reference
 **Purpose**: Reference to genus-0 modular function at SSP prime
-
 **Data layout**:
 ```
 [prime_idx:4][genus:4][coeff_idx:8][coeff_val:28]
 ```
-
 **Terms**:
 - **prime_idx**: SSP index (0-14)
-- **genus**: Genus of Xâ‚€(p) (0-6)
+- **genus**: Genus of X₀(p) (0-6)
   - p=2,3,5,7,13: genus 0
   - p=11,17,19: genus 1
   - p=23,29,31: genus 2
@@ -285,123 +250,193 @@ trivector structure.
   - p=59: genus 5
   - p=71: genus 6
 - **coeff_idx**: McKay-Thompson coefficient index n (0-255)
-- **coeff_val**: Coefficient value c_n(pa) mod 2Â²â¸
-
+- **coeff_val**: Coefficient value c_n(pa) mod 2²⁸
 **Example**: `0xDA5170060000030E`
 - prefix: 0xDA51
 - type: 7 (Hauptmodul)
 - prime_idx: 0 (prime 2)
 - genus: 0
 - coeff_idx: 1
-- coeff_val: 782 (câ‚(3a))
-
+- coeff_val: 782 (c₁(3a))
+### Type 8: Meme  *(new)*
+**Purpose**: Name one FRACTRAN Hilbert-life **biome** (a "meme") of
+`RequestProject.Biome`, at a chosen render setting.
+A *meme* is the minimal data that reconstructs one biome animation
+(`RequestProject.MemeUrl.Meme`): the render `order` and `frameMs`, the biome's
+OEIS **A001379** `index`, and the fifteen p-adic exponents `exps`. Everything else
+the animation needs — the prime support, the characteristic number
+`N = ∏ pᵉ`, the FRACTRAN mutation program, the colour palette, the automaton
+rules, and the seed board — is a *pure function* of those fields (the
+`RequestProject.Biome` API). Following the RFC-0001 rule, **derived quantities are
+never stored**, only recomputed.
+**Data layout** (44 data bits):
+```
+[order:6][frame:18][index:12][pad:8]
+```
+**Terms**:
+- **order**: 0-63 — render Hilbert order; the board is a `2^order × 2^order`
+  grid whose cells are indexed by Hilbert distance (the automaton literally runs
+  on top of the space-filling curve). Valid memes use `order < 62`.
+- **frame**: 0-262143 — milliseconds between automaton ticks in the animation.
+  Valid memes use `frameMs < 62³ = 238328`.
+- **index**: 0-4095 — A001379 biome index. The full 15-entry `exps` vector is
+  **derived** by table lookup: `exps = Biome.table[index].exps`, aligned with the
+  fifteen tracked primes (which are exactly the SSP set, see below). The project
+  table has 194 rows, `index ∈ 0 … 193`; valid memes use `index < 62² = 3844`.
+- **pad**: reserved (0).
+Because `index` alone selects the exponent vector, the 44 data bits suffice to
+name any biome; the exps are recomputed, never transmitted — exactly parallel to
+Type 6/Type 7, which also store an SSP index and recompute the moonshine data.
+**Example**: `0xDA51810008C00E00`
+- prefix: 0xDA51
+- type: 8 (Meme)
+- order: 4
+- frame: 140
+- index: 14  ⇒  `exps = [12,0,0,4,1,2,0,0,0,0,1,0,0,1,1]`,
+  i.e. `N = 2¹²·7⁴·11·13²·31·59·71 = 2374124840062976`
+- pad: 0
+This is biome #14, whose `meme:` URL is `meme:4G20E0FC00412000010011`. The
+address ↔ URL correspondence is verified in Lean: see
+`RequestProject.Da51.encodeMeme`/`toMeme` and the round-trip theorems
+(`getOrder_encodeMeme`, `getFrame_encodeMeme`, `getIndex_encodeMeme`,
+`getType_encodeMeme`, `getPrefix_encodeMeme`, and `toMeme_ofMeme` for the full
+table-backed identity). `#eval RequestProject.Da51.toHex (RequestProject.Da51.encodeMeme 4 140 14)`
+prints `da51810008c00e00`.
+**Eigenspace tag (derived).** A meme's biome sits inside the Cl(15,0,0)
+eigenspace partition through its exponent vector: the support primes with
+positive exponent fall into Earth / Spoke / Hub / Clock (see the eigenspace
+table below). The c₁-weighted "energy" of a meme is therefore ≈99.9996% Earth,
+so a Type 8 address can be *rewritten* to a Type 6 (Eigenspace) address for
+priority routing by projecting `exps` onto the eigenspaces — the two types share
+the same fifteen SSP primes.
+## The memes and the SSP primes
+The fifteen primes the biome table tracks,
+```
+[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 41, 47, 59, 71]
+```
+(`RequestProject.Biome.primes`),
+are **identical** to the fifteen supersingular / Monster primes on which the whole
+0xDA51 Cl(15,0,0) construction rests (`47 × 59 × 71 = 196883`). This is not a
+coincidence of naming: it means every meme's "genome" lives in the same prime
+lattice as the Monster addressing, and the Earth/Spoke/Hub/Clock eigenspaces
+classify a biome's prime support directly.
+- A biome's **prime support** (primes with positive exponent) is always a subset
+  of the fifteen SSP primes.
+- The **FRACTRAN mutation program** of a biome cycles a factor forward through
+  exactly that biome's support primes, so object genomes churn through the SSP
+  lattice — a FRACTRAN realisation of a walk on the Monster primes.
+- The **colour/palette** hue is fixed per biome and shaded by how many support
+  primes divide the current genome.
+## FRACTRAN (memes)
+- **Memes as state**: each biome is a FRACTRAN program over the SSP primes; every
+  living object carries an integer genome that advances one FRACTRAN step per
+  automaton tick. Prime factorisation is the genome, and it picks the colour.
+- **State compression to CIDs**: a meme's `(order, frame, index)` compresses to a
+  single Type 8 0xDA51 address (`RequestProject.Da51.encodeMeme`); its `exps` and
+  the derived program are recomputed from `index`.
+- **Prime factorization encoding**: the fifteen `exps` are the p-adic valuations
+  of the biome's characteristic `N = ∏ pᵉ` at the SSP primes.
+- **Unlimited precision via BigUint**: genomes grow without bound as FRACTRAN
+  runs; the animation renders the churn as an SVG side effect.
+- **DAG-CBOR enumeration**: the whole set of memes is content-addressed and
+  enumerated as IPLD DAG-CBOR blocks with a single catalog CID; see
+  `docs/rfc-0001-meme-ipld-dagcbor.md`. A Type 8 0xDA51 address and a DAG-CBOR
+  meme block carry the same five logical fields.
 ## Cl(15,0,0) Eigendecomposition (Experiments 1-11)
-
-### Operator O = Hubâ‚â‚‰ Â· Zâ‚‚
-
-The canonical operator O in Cl(15,0,0) is a grade-(1,3) versor with Oâ¶ = 1.
-- **Char poly**: (Î»âˆ’1)(Î»+1)Â¹Â²(Î»Â²âˆ’Î»+1)
-- **O âˆˆ GL(15,â„š)**: all entries multiples of 1/4
-
+### Operator O = Hub₁₉ · Z₂
+The canonical operator O in Cl(15,0,0) is a grade-(1,3) versor with O⁶ = 1.
+- **Char poly**: (λ−1)(λ+1)¹²(λ²−λ+1)
+- **O ∈ GL(15,ℚ)**: all entries multiples of 1/4
 ### Eigenspace Partition
-
 | Eigenspace | Dim | Eigenvalue | Basis | Role |
 |---|---|---|---|---|
-| Earth + 47 | 7 | âˆ’1 | eâ‚‚,eâ‚ƒ,eâ‚…,eâ‚‡,eâ‚â‚,eâ‚â‚ƒ,eâ‚„â‚‡ | Pure, decoupled |
-| Spokes | 5 | âˆ’1 | eâ‚â‚‡âˆ’eâ‚‚â‚‰, eâ‚â‚‡+eâ‚ƒâ‚, eâ‚â‚‡âˆ’eâ‚„â‚, eâ‚â‚‡âˆ’eâ‚…â‚‰, eâ‚â‚‡+eâ‚‡â‚ | Mixed |
-| Hub axis | 1 | +1 | (eâ‚â‚‰+eâ‚‚â‚ƒ)/âˆš2 | Fixed point |
-| Clock | 2 | e^{Â±iÏ€/3} | (eâ‚â‚‰âˆ’eâ‚‚â‚ƒ)/âˆš2 and spoke-average câ‚€ | 60Â° rotation |
-
-Total: 7 + 5 + 1 + 2 = 15 âœ“
-
+| Earth + 47 | 7 | −1 | e₂,e₃,e₅,e₇,e₁₁,e₁₃,e₄₇ | Pure, decoupled |
+| Spokes | 5 | −1 | e₁₇−e₂₉, e₁₇+e₃₁, e₁₇−e₄₁, e₁₇−e₅₉, e₁₇+e₇₁ | Mixed |
+| Hub axis | 1 | +1 | (e₁₉+e₂₃)/√2 | Fixed point |
+| Clock | 2 | e^{±iπ/3} | (e₁₉−e₂₃)/√2 and spoke-average c₀ | 60° rotation |
+Total: 7 + 5 + 1 + 2 = 15 ✓
+Every meme's prime support projects onto this partition; the Type 8 → Type 6
+rewrite uses exactly this map.
 ### Class A / Class B Partition
-
-- **Class A (Earth)**: {2, 3, 5, 7, 11, 13} â€” 1-nibble primes, high exponents, eigenvalue âˆ’1
-- **Class B (Heaven)**: {17, 19, 23, 29, 31, 41, 47, 59, 71} â€” 2-nibble primes
-- **47 anomaly**: Class B prime that behaves like Class A (pure âˆ’1, decoupled)
-- **Hub pair**: {19, 23} â€” carries the +1 eigenvector and 60Â° clock
-
+- **Class A (Earth)**: {2, 3, 5, 7, 11, 13} — 1-nibble primes, high exponents, eigenvalue −1
+- **Class B (Heaven)**: {17, 19, 23, 29, 31, 41, 47, 59, 71} — 2-nibble primes
+- **47 anomaly**: Class B prime that behaves like Class A (pure −1, decoupled)
+- **Hub pair**: {19, 23} — carries the +1 eigenvector and 60° clock
 ### The 196,883 Triangle (GAP-verified)
-
 ```
-47 Ã— 59 Ã— 71 = 196,883
+47 × 59 × 71 = 196,883
 ```
-
-- **Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(47a) = Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(59a) = Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(71a) = 0** (all invisible)
-- **|C_M(47a)| = 94 = 2Â·47**, |C_M(59a)| = 59, |C_M(71a)| = 71
-- No classes of order 47Â·59, 47Â·71, or 59Â·71 exist (orthogonal pillars)
-- For p â‰¥ 13: **Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ(pa) = 196883 mod p** exactly
-- The trivector eâ‚„â‚‡âˆ§eâ‚…â‚‰âˆ§eâ‚‡â‚ maps under O with ratio **âˆ’1/2 = Re(Ï‰Â²)**
-
+- **χ₁₉₆₈₈₃(47a) = χ₁₉₆₈₈₃(59a) = χ₁₉₆₈₈₃(71a) = 0** (all invisible)
+- **|C_M(47a)| = 94 = 2·47**, |C_M(59a)| = 59, |C_M(71a)| = 71
+- No classes of order 47·59, 47·71, or 59·71 exist (orthogonal pillars)
+- For p ≥ 13: **χ₁₉₆₈₈₃(pa) = 196883 mod p** exactly
+- The trivector e₄₇∧e₅₉∧e₇₁ maps under O with ratio **−1/2 = Re(ω²)**
 ### Skeleton Pair {3, 19}
-
 Hex walk of |M| = 0x86FA3F510644E13FDC4C5673C27C78C31400000000000:
-- Group 1 "86F": strip {2â´â¶, 7â¶, 11Â², 17, 71}
-- Group 2 "A3": strip {13Â³, 23, 29, 41, 59}
-- Group 3 "F": strip {5â¹, 31, 47}
-- **Remaining: {3, 19}** â€” irreducible skeleton
-- 3Â²â° = dominant odd exponent, 19 = hub prime (+1 eigenvector)
-- Hex nibble sum = 240 = 16 Ã— 15 = |roots of Eâ‚ˆ|
-
+- Group 1 "86F": strip {2⁴⁶, 7⁶, 11², 17, 71}
+- Group 2 "A3": strip {13³, 23, 29, 41, 59}
+- Group 3 "F": strip {5⁹, 31, 47}
+- **Remaining: {3, 19}** — irreducible skeleton
+- 3²⁰ = dominant odd exponent, 19 = hub prime (+1 eigenvector)
+- Hex nibble sum = 240 = 16 × 15 = |roots of E₈|
 ### McKay-Thompson Hauptmoduln
-
-câ‚ = Ï‡â‚â‚‰â‚†â‚ˆâ‚ˆâ‚ƒ on SSP classes:
-
-| Prime | câ‚ | câ‚‚ | câ‚ƒ | Eigenspace | 196883 mod p |
+c₁ = χ₁₉₆₈₈₃ on SSP classes:
+| Prime | c₁ | c₂ | c₃ | Eigenspace | 196883 mod p |
 |-------|-----|------|------|------------|-------------|
-| 2 | 4371 | 96256 | 1240001 | Earth (âˆ’1) | 1 |
-| 3 | 782 | 8672 | 65366 | Earth (âˆ’1) | 2 |
-| 5 | 133 | 760 | 3344 | Earth (âˆ’1) | 3 |
-| 7 | 50 | 204 | 680 | Earth (âˆ’1) | 1 |
-| 11 | 16 | 46 | 115 | Earth (âˆ’1) | 5 |
-| 13 | 11 | 28 | 65 | Earth (âˆ’1) | 11 |
-| 17 | 6 | 14 | 28 | Spoke (âˆ’1) | 6 |
+| 2 | 4371 | 96256 | 1240001 | Earth (−1) | 1 |
+| 3 | 782 | 8672 | 65366 | Earth (−1) | 2 |
+| 5 | 133 | 760 | 3344 | Earth (−1) | 3 |
+| 7 | 50 | 204 | 680 | Earth (−1) | 1 |
+| 11 | 16 | 46 | 115 | Earth (−1) | 5 |
+| 13 | 11 | 28 | 65 | Earth (−1) | 11 |
+| 17 | 6 | 14 | 28 | Spoke (−1) | 6 |
 | 19 | 5 | 10 | 20 | Hub (+1) | 5 |
-| 23 | 3 | 7 | 12 | Hub (Ï‰) | 3 |
-| 29 | 2 | 4 | 6 | Spoke (âˆ’1) | 2 |
-| 31 | 2 | 3 | 5 | Spoke (âˆ’1) | 2 |
-| 41 | 1 | 2 | 2 | Spoke (âˆ’1) | 1 |
-| 47 | 0 | 2 | 2 | Earth (âˆ’1) | **0** |
-| 59 | 0 | 1 | 1 | Spoke (âˆ’1) | **0** |
-| 71 | 0 | 1 | 0 | Spoke (âˆ’1) | **0** |
-
-- câ‚ vector is **99.9996%** in the âˆ’1 eigenspace of O
-- Hub axis projection: (5+3)/âˆš2 = 4âˆš2, Clock: (5âˆ’3)/âˆš2 = âˆš2 â†’ ratio 4:1
-- |câ‚|Â² = 19,737,810 = 2Â·3Â·5Â·7Â·**19**Â·9901
-- 782 + 5 = **787** (prime) â€” skeleton pair contribution is irreducible
-
+| 23 | 3 | 7 | 12 | Hub (ω) | 3 |
+| 29 | 2 | 4 | 6 | Spoke (−1) | 2 |
+| 31 | 2 | 3 | 5 | Spoke (−1) | 2 |
+| 41 | 1 | 2 | 2 | Spoke (−1) | 1 |
+| 47 | 0 | 2 | 2 | Earth (−1) | **0** |
+| 59 | 0 | 1 | 1 | Spoke (−1) | **0** |
+| 71 | 0 | 1 | 0 | Spoke (−1) | **0** |
+- c₁ vector is **99.9996%** in the −1 eigenspace of O
+- Hub axis projection: (5+3)/√2 = 4√2, Clock: (5−3)/√2 = √2 → ratio 4:1
+- |c₁|² = 19,737,810 = 2·3·5·7·**19**·9901
+- 782 + 5 = **787** (prime) — skeleton pair contribution is irreducible
 ## Mathematical Terms
-
 ### Monster Group
 - **Order**: 808,017,424,794,512,875,886,459,904,961,710,757,005,754,368,000,000,000
 - **Hex**: 0x86FA3F510644E13FDC4C5673C27C78C31400000000000 (45 nibbles, 180 bits)
-- **Factorization**: 2â´â¶ Â· 3Â²â° Â· 5â¹ Â· 7â¶ Â· 11Â² Â· 13Â³ Â· 17 Â· 19 Â· 23 Â· 29 Â· 31 Â· 41 Â· 47 Â· 59 Â· 71
-- **Smallest representation**: 196,883 = 47 Ã— 59 Ã— 71
-- **Skeleton pair**: {3, 19} â€” survives all hex walk stripping
-- **Deformation norm**: 3âˆš(19/2) â€” encodes hub prime
-
+- **Factorization**: 2⁴⁶ · 3²⁰ · 5⁹ · 7⁶ · 11² · 13³ · 17 · 19 · 23 · 29 · 31 · 41 · 47 · 59 · 71
+- **Smallest representation**: 196,883 = 47 × 59 × 71
+- **Skeleton pair**: {3, 19} — survives all hex walk stripping
+- **Deformation norm**: 3√(19/2) — encodes hub prime
 ### Bott Periodicity
 - **Period**: 8
-- **Sequence**: R, C, H, HâŠ•H, H(2), C(4), R(8), R(8)âŠ•R(8), then repeats
+- **Sequence**: R, C, H, H⊕H, H(2), C(4), R(8), R(8)⊕R(8), then repeats
 - **Topological**: K-theory periodicity in 8 dimensions
-
 ### 10-Fold Way
 - **Altland-Zirnbauer classification**: 10 symmetry classes
 - **Topological phases**: Quantum matter classification
 - **Clifford algebras**: Cl(p,q) with p+q=10
-
 ### Hecke Operators
 - **Definition**: T_p acting on modular forms
 - **Primes**: 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 41, 47, 59, 71
 - **Error correction**: Reed-Solomon with Hecke structure
-
 ### Supersingular Primes
 - **OEIS A002267**: 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 41, 47, 59, 71
 - **Elliptic curves**: Primes where supersingular curves exist
 - **Moonshine**: Connection to Monster Group
-
+- **Memes**: the same fifteen primes are `RequestProject.Biome.primes`, the p-adic
+  axes of every biome's exponent vector (see Type 8).
+### Memes (biomes)
+- **Definition**: one FRACTRAN Hilbert-life biome per OEIS **A001379** number
+  (`RequestProject.Biome`), rendered as an animated SVG.
+- **URL**: `meme:` + base-62 payload (`RequestProject.MemeUrl`), a total,
+  round-tripping serialization (`ofUrl (toUrl m) = some m`).
+- **0xDA51 address**: Type 8 (this document), `RequestProject.Da51`.
+- **Enumeration**: IPLD DAG-CBOR catalog CID (`docs/rfc-0001-meme-ipld-dagcbor.md`).
+- **Count**: 194 biomes in the project table (`index ∈ 0 … 193`).
 ## Composition Rules
-
 ### XOR Merge
 ```rust
 fn merge_cids(cid1: u64, cid2: u64) -> u64 {
@@ -411,10 +446,8 @@ fn merge_cids(cid1: u64, cid2: u64) -> u64 {
     prefix | (data1 ^ data2)
 }
 ```
-
 **Preserves**: Common prefix 0xDA51
 **Combines**: Type-specific data via XOR
-
 ### Harmonic Sliding
 ```rust
 fn slide(cid_10fold: u64, cid_8fold: u64) -> u64 {
@@ -423,12 +456,9 @@ fn slide(cid_10fold: u64, cid_8fold: u64) -> u64 {
     monster_cid_from_harmonic(sum)
 }
 ```
-
-**Bridges**: 10-fold way â†” 8-fold way
+**Bridges**: 10-fold way ↔ 8-fold way
 **Via**: 80 prime transitions
-
 ## Usage Examples
-
 ### AST Node Encoding
 ```rust
 // Lean4 bvar: (R, Cl(10,0), T_71)
@@ -440,7 +470,6 @@ let cid = encode_ast_node(
 );
 // Result: 0xDA51E0000011C000
 ```
-
 ### File Addressing
 ```rust
 // zkerdfa_compiler.rs
@@ -452,7 +481,6 @@ let cid = encode_nested_cid(
 );
 // Result: 0xDA513AE3392F2B7F
 ```
-
 ### Protocol Negotiation
 ```rust
 // zkERDFA Solana program
@@ -463,67 +491,67 @@ let cid = encode_protocol(
 );
 // Result: 0xDA52010000000001
 ```
-
+### Meme Encoding *(new)*
+```lean
+-- biome #14 at the gallery render defaults (order = 4, frameMs = 140)
+#eval RequestProject.Da51.toHex
+        (RequestProject.Da51.encodeMeme 4 140 14)
+-- Result: "da51810008c00e00"   (0xDA51810008C00E00)
+-- decode back to a meme (exps recomputed from the A001379 table):
+#eval RequestProject.Da51.toMeme 0xDA51810008C00E00
+-- { order := 4, frameMs := 140, index := 14,
+--   exps := [12,0,0,4,1,2,0,0,0,0,1,0,0,1,1] }
+```
+Round trip proved in `RequestProject.Da51` (`toMeme_ofMeme`).
 ## Address Space
-
 **Total**: 2^64 = 18,446,744,073,709,551,616 addresses
-
-**Types** (as of 2026-03-14):
+**Types** (as of 2026-07-11):
 - Type 0 (Monster Walk): 10 addresses
 - Type 1 (AST Node): ~9,400 addresses
 - Type 3 (Nested CID): ~35,000 addresses
-- Type 6 (Eigenspace): 4 eigenspaces Ã— 15 primes Ã— 2Â²â¸ hashes
-- Type 7 (Hauptmodul): 15 primes Ã— 256 coefficients
-- **Total**: ~44,410+ addresses (0.00000024%)
-
+- Type 6 (Eigenspace): 4 eigenspaces × 15 primes × 2²⁸ hashes
+- Type 7 (Hauptmodul): 15 primes × 256 coefficients
+- Type 8 (Meme): 194 biomes × 62 orders × 62³ frames of *reachable* addresses
+  (data field capacity 2⁴⁴; the project table realises 194 `index` values)
+- **Total**: ~44,600+ addresses (0.00000024%)
 ## Integration Points
-
 ### IPFS/IPLD
 - CID v1 compatible
 - dag-cbor codec (0x71)
 - Multihash sha2-256 (0x12)
-
+- **Memes**: enumerated as DAG-CBOR blocks with a catalog CID
+  (`docs/rfc-0001-meme-ipld-dagcbor.md`)
 ### Solana
 - zkERDFA program instructions
 - Payment in Heiliger Geist (HG)
 - 196,883 lamports per novel unit
-
 ### FRACTRAN
 - State compression to CIDs
 - Prime factorization encoding
 - Unlimited precision via BigUint
-
+- **Memes**: each biome *is* a FRACTRAN program over the SSP primes; its genome
+  advances one step per automaton tick (`RequestProject.Biome`,
+  `RequestProject.Fractran`)
 ## References
-
 - **Monster Group**: https://www.wikidata.org/wiki/Q333871
 - **Bott Periodicity**: https://en.wikipedia.org/wiki/Bott_periodicity_theorem
 - **10-Fold Way**: https://en.wikipedia.org/wiki/Topological_order
 - **Hecke Operators**: https://en.wikipedia.org/wiki/Hecke_operator
 - **Supersingular Primes**: https://oeis.org/A002267
-
+- **Memes / biomes**: OEIS A001379; project modules `RequestProject.Biome`,
+  `RequestProject.MemeUrl`, `RequestProject.MemeUrlProofs`, `RequestProject.Da51`;
+  and `docs/rfc-0001-meme-ipld-dagcbor.md`.
 ---
-
-ðŸ”¢ **0xDA51** = DASL prefix
-ðŸ‘‘ **196,883** = 47 Ã— 59 Ã— 71 (invisible trivector, ratio âˆ’1/2 under O)
-ðŸŒ **Earth** = {2,3,5,7,11,13,47} eigenvalue âˆ’1 (99.9996% of moonshine energy)
-ðŸ”® **Hub** = {19,23} eigenvalue +1, skeleton survivor
-â° **Clock** = 60Â° rotation, period 6, char poly (Î»âˆ’1)(Î»+1)Â¹Â²(Î»Â²âˆ’Î»+1)
-ðŸ’€ **Skeleton** = {3, 19} â€” irreducible core of |M|
-ðŸ“ **Cl(15,0,0)** = Clifford algebra of the 15 supersingular primes
-ðŸ”‘ **240** = hex nibble sum of |M| = 16 Ã— 15 = |roots of Eâ‚ˆ|
-ðŸŽ¯ **2â¶â´** = Total address space
-
-
-
-  
-  
-  
-  
-  
-  
-
-
-
+🔢 **0xDA51** = DASL prefix
+👑 **196,883** = 47 × 59 × 71 (invisible trivector, ratio −1/2 under O)
+🌍 **Earth** = {2,3,5,7,11,13,47} eigenvalue −1 (99.9996% of moonshine energy)
+🔮 **Hub** = {19,23} eigenvalue +1, skeleton survivor
+⏰ **Clock** = 60° rotation, period 6, char poly (λ−1)(λ+1)¹²(λ²−λ+1)
+💀 **Skeleton** = {3, 19} — irreducible core of |M|
+📐 **Cl(15,0,0)** = Clifford algebra of the 15 supersingular primes
+🔑 **240** = hex nibble sum of |M| = 16 × 15 = |roots of E₈|
+🎯 **2⁶⁴** = Total address space
+🧬 **Type 8 = Meme** = one FRACTRAN Hilbert-life biome (A001379) over the same 15 SSP primes
 <div typeof="erdfa:SheafSection" about="#bafkda5130a24023b498">
   <meta property="erdfa:shard" content="16,2,0" />
   <meta property="erdfa:encoding" content="raw" />


### PR DESCRIPTION
This update revises the 0xDA51 taxonomy to include a new Type 8 address for memes, enhancing the original classification with additional keywords and correcting mojibake issues.